### PR TITLE
RE: Add access to equipment array in savedata

### DIFF
--- a/base/core/FFX/savedata.cs
+++ b/base/core/FFX/savedata.cs
@@ -2,64 +2,70 @@
 
 [StructLayout(LayoutKind.Explicit, Pack = 4, Size = 0x68C0)]
 public unsafe struct SaveData {
-    [FieldOffset(0x0)]    public       ushort       current_room_id;
-    [FieldOffset(0x2)]    public       ushort       last_room_id;
-    [FieldOffset(0x4)]    public       ushort       now_eventjump_map_no;
-    [FieldOffset(0x6)]    public       ushort       last_eventjump_map_no;
-    [FieldOffset(0x8)]    public       ushort       now_eventjump_map_id;
-    [FieldOffset(0xA)]    public       ushort       last_eventjump_map_id;
-    [FieldOffset(0xC)]    public       byte         current_spawnpoint;
-    [FieldOffset(0xD)]    public       byte         last_spawnpoint;
-    [FieldOffset(0xE)]    public       ushort       atel_save_dic_index;
-    [FieldOffset(0x10)]   public       byte         atel_battle_scene_group;
-    [FieldOffset(0x20)]   public       byte         atel_is_push_member;
-    [FieldOffset(0x21)]   public fixed byte         atel_push_frontline[3];
-    [FieldOffset(0x24)]   public       byte         atel_push_party;
-    [FieldOffset(0x28)]   public       byte         is_cam_underwater;
-    [FieldOffset(0x29)]   public       byte         is_map_underwater;
-    [FieldOffset(0x2B)]   public       byte         tk_event_new_game;
-    [FieldOffset(0x2C)]   public fixed uint         affection[8];
-    [FieldOffset(0xD1)]   public       byte         albhed_rikku;
-    [FieldOffset(0xD6)]   public       byte         atel_force_place_id;
-    [FieldOffset(0xD7)]   public       byte         atel_water_btl_effect;
-    [FieldOffset(0xD8)]   public       uint         on_memory_movie_file_no;
-    [FieldOffset(0xDC)]   public       uint         on_memory_movie_mode;
-    [FieldOffset(0xE0)]   public       uint         on_memory_movie;
-    [FieldOffset(0xE4)]   public       int          rand_encounter_modifiers;
-    [FieldOffset(0xE8)]   public       ushort       btl_end_tag_always;
-    [FieldOffset(0xEA)]   public       ushort       sphere_monitor;
-    [FieldOffset(0xBEC)]  public       ushort       story_progress;
-    [FieldOffset(0xC81)]  public       ushort       unlocked_airship_destinations;
-    [FieldOffset(0x3D0C)] public       uint         config;
-    [FieldOffset(0x3D10)] public       uint         unlocked_primers;
-    [FieldOffset(0x3D14)] public       uint         battle_count;
-    [FieldOffset(0x3D48)] public       uint         gil;
-    [FieldOffset(0x3D58)] public fixed byte         party_order[7];
-    [FieldOffset(0x3DA4)] public       uint         yojimbo_compatibility;
-    [FieldOffset(0x3DB0)] public       uint         successful_rikku_steals;
-    [FieldOffset(0x3DB4)] public       uint         bribe_gil_spent;
-    [FieldOffset(0x3ECC)] public fixed T_XCommandId inventory_ids[70];
-    [FieldOffset(0x40CC)] public fixed byte         inventory_counts[70];
-    [FieldOffset(0x448C)] public       uint         ptr_important_bin;
-    [FieldOffset(0x55CC)] public       PlySave      ply_tidus;
-    [FieldOffset(0x5660)] public       PlySave      ply_yuna;
-    [FieldOffset(0x56F4)] public       PlySave      ply_auron;
-    [FieldOffset(0x5788)] public       PlySave      ply_kimahri;
-    [FieldOffset(0x581C)] public       PlySave      ply_wakka;
-    [FieldOffset(0x58B0)] public       PlySave      ply_lulu;
-    [FieldOffset(0x5944)] public       PlySave      ply_rikku;
-    [FieldOffset(0x59D8)] public       PlySave      ply_seymour;
-    [FieldOffset(0x5A6C)] public       PlySave      ply_valefor;
-    [FieldOffset(0x5B00)] public       PlySave      ply_ifrit;
-    [FieldOffset(0x5B94)] public       PlySave      ply_ixion;
-    [FieldOffset(0x5C28)] public       PlySave      ply_shiva;
-    [FieldOffset(0x5CBC)] public       PlySave      ply_bahamut;
-    [FieldOffset(0x5D50)] public       PlySave      ply_anima;
-    [FieldOffset(0x5DE4)] public       PlySave      ply_yojimbo;
-    [FieldOffset(0x5E78)] public       PlySave      ply_cindy;
-    [FieldOffset(0x5F0C)] public       PlySave      ply_sandy;
-    [FieldOffset(0x5FA0)] public       PlySave      ply_mindy;
-    [FieldOffset(0x634C)] public fixed byte         character_names[360]; // each name is at most 20 bytes long. C# won't let me make a 2D array
+    [InlineArray(200)]
+    public struct EquipmentArray {
+        private Equipment _data;
+    }
+
+    [FieldOffset(0x0)]    public       ushort         current_room_id;
+    [FieldOffset(0x2)]    public       ushort         last_room_id;
+    [FieldOffset(0x4)]    public       ushort         now_eventjump_map_no;
+    [FieldOffset(0x6)]    public       ushort         last_eventjump_map_no;
+    [FieldOffset(0x8)]    public       ushort         now_eventjump_map_id;
+    [FieldOffset(0xA)]    public       ushort         last_eventjump_map_id;
+    [FieldOffset(0xC)]    public       byte           current_spawnpoint;
+    [FieldOffset(0xD)]    public       byte           last_spawnpoint;
+    [FieldOffset(0xE)]    public       ushort         atel_save_dic_index;
+    [FieldOffset(0x10)]   public       byte           atel_battle_scene_group;
+    [FieldOffset(0x20)]   public       byte           atel_is_push_member;
+    [FieldOffset(0x21)]   public fixed byte           atel_push_frontline[3];
+    [FieldOffset(0x24)]   public       byte           atel_push_party;
+    [FieldOffset(0x28)]   public       byte           is_cam_underwater;
+    [FieldOffset(0x29)]   public       byte           is_map_underwater;
+    [FieldOffset(0x2B)]   public       byte           tk_event_new_game;
+    [FieldOffset(0x2C)]   public fixed uint           affection[8];
+    [FieldOffset(0xD1)]   public       byte           albhed_rikku;
+    [FieldOffset(0xD6)]   public       byte           atel_force_place_id;
+    [FieldOffset(0xD7)]   public       byte           atel_water_btl_effect;
+    [FieldOffset(0xD8)]   public       uint           on_memory_movie_file_no;
+    [FieldOffset(0xDC)]   public       uint           on_memory_movie_mode;
+    [FieldOffset(0xE0)]   public       uint           on_memory_movie;
+    [FieldOffset(0xE4)]   public       int            rand_encounter_modifiers;
+    [FieldOffset(0xE8)]   public       ushort         btl_end_tag_always;
+    [FieldOffset(0xEA)]   public       ushort         sphere_monitor;
+    [FieldOffset(0xBEC)]  public       ushort         story_progress;
+    [FieldOffset(0xC81)]  public       ushort         unlocked_airship_destinations;
+    [FieldOffset(0x3D0C)] public       uint           config;
+    [FieldOffset(0x3D10)] public       uint           unlocked_primers;
+    [FieldOffset(0x3D14)] public       uint           battle_count;
+    [FieldOffset(0x3D48)] public       uint           gil;
+    [FieldOffset(0x3D58)] public fixed byte           party_order[7];
+    [FieldOffset(0x3DA4)] public       uint           yojimbo_compatibility;
+    [FieldOffset(0x3DB0)] public       uint           successful_rikku_steals;
+    [FieldOffset(0x3DB4)] public       uint           bribe_gil_spent;
+    [FieldOffset(0x3ECC)] public fixed T_XCommandId   inventory_ids[70];
+    [FieldOffset(0x40CC)] public fixed byte           inventory_counts[70];
+    [FieldOffset(0x448C)] public       uint           ptr_important_bin;
+    [FieldOffset(0x449C)] public       EquipmentArray equipment;
+    [FieldOffset(0x55CC)] public       PlySave        ply_tidus;
+    [FieldOffset(0x5660)] public       PlySave        ply_yuna;
+    [FieldOffset(0x56F4)] public       PlySave        ply_auron;
+    [FieldOffset(0x5788)] public       PlySave        ply_kimahri;
+    [FieldOffset(0x581C)] public       PlySave        ply_wakka;
+    [FieldOffset(0x58B0)] public       PlySave        ply_lulu;
+    [FieldOffset(0x5944)] public       PlySave        ply_rikku;
+    [FieldOffset(0x59D8)] public       PlySave        ply_seymour;
+    [FieldOffset(0x5A6C)] public       PlySave        ply_valefor;
+    [FieldOffset(0x5B00)] public       PlySave        ply_ifrit;
+    [FieldOffset(0x5B94)] public       PlySave        ply_ixion;
+    [FieldOffset(0x5C28)] public       PlySave        ply_shiva;
+    [FieldOffset(0x5CBC)] public       PlySave        ply_bahamut;
+    [FieldOffset(0x5D50)] public       PlySave        ply_anima;
+    [FieldOffset(0x5DE4)] public       PlySave        ply_yojimbo;
+    [FieldOffset(0x5E78)] public       PlySave        ply_cindy;
+    [FieldOffset(0x5F0C)] public       PlySave        ply_sandy;
+    [FieldOffset(0x5FA0)] public       PlySave        ply_mindy;
+    [FieldOffset(0x634C)] public fixed byte           character_names[360]; // each name is at most 20 bytes long. C# won't let me make a 2D array
 
     public ReadOnlySpan<PlySave> ply_arr => MemoryMarshal.CreateReadOnlySpan(ref ply_tidus, 18);
 


### PR DESCRIPTION
How did we not have this yet it's been known for months
Also, this formatting makes git diff hell so here's the actual diff:
```diff
  3     [StructLayout(LayoutKind.Explicit, Pack = 4, Size = 0x68C0)]
  4     public unsafe struct SaveData {
+ 5         [InlineArray(200)]                                                             
+ 6         public struct EquipmentArray {                                                 
+ 7             private Equipment _data;                                                   
+ 8         }                                                                              
+ 9                                                                                        
=====================================================
  48        [FieldOffset(0x448C)] public       uint           ptr_important_bin;
+ 49        [FieldOffset(0x449C)] public       EquipmentArray equipment;                   
  50        [FieldOffset(0x55CC)] public       PlySave        ply_tidus;
```