### PR TITLE
Capture-related fields

### DIFF
--- a/core/ffx/Battle/btl.cs
+++ b/core/ffx/Battle/btl.cs
@@ -233,7 +233,11 @@ public unsafe struct Btl {
     [FieldOffset(0x2008)] public       uint   last_com;
     [FieldOffset(0x210C)] public       byte   ambush_state;
 
-    // Can only capture monsters if 0. save_data->tidus_limit_uses only increases if not 2. Cannot steal if 2? PlySave battle_count and enemies_defeated fields only increment if not 2.
+    // In vanilla:
+    // - Can only capture monsters if 0.
+    // - save_data->tidus_limit_uses only increases if not 2.
+    // - Cannot steal if 2?
+    // - PlySave battle_count and enemies_defeated fields only increment if not 2.
     [FieldOffset(0x2115)] public       byte   battle_type; 
 
     [FieldOffset(0x2121)] public       byte   battle_end_type;

--- a/core/ffx/Battle/btl.cs
+++ b/core/ffx/Battle/btl.cs
@@ -232,5 +232,9 @@ public unsafe struct Btl {
 
     [FieldOffset(0x2008)] public       uint   last_com;
     [FieldOffset(0x210C)] public       byte   ambush_state;
+
+    // Can only capture monsters if 0. save_data->tidus_limit_uses only increases if not 2. Cannot steal if 2? PlySave battle_count and enemies_defeated fields only increment if not 2.
+    [FieldOffset(0x2115)] public       byte   battle_type; 
+
     [FieldOffset(0x2121)] public       byte   battle_end_type;
 }

--- a/core/ffx/Battle/chr.cs
+++ b/core/ffx/Battle/chr.cs
@@ -193,6 +193,8 @@ public unsafe struct Chr {
     [FieldOffset(0xDCC)] public byte     stat_death;
     [FieldOffset(0xDCD)] public bool     stat_escape_flag;
     [FieldOffset(0xDCE)] public byte     stat_stone;
+    [FieldOffset(0xDD0)] public bool     capture;  // Set to True in MsCalcCommand if command uses weapon properties and attacker has Capture auto-ability
+    [FieldOffset(0xDD1)] public bool     captured; // Set to True on death if capture is True and the monster has a valid capture index
     [FieldOffset(0xDD2)] public bool     stat_exist_flag;
     [FieldOffset(0xDD6)] public byte     stat_action;
     [FieldOffset(0xDD7)] public bool     in_ctb_list;

--- a/core/ffx/Battle/chr.cs
+++ b/core/ffx/Battle/chr.cs
@@ -193,8 +193,8 @@ public unsafe struct Chr {
     [FieldOffset(0xDCC)] public byte     stat_death;
     [FieldOffset(0xDCD)] public bool     stat_escape_flag;
     [FieldOffset(0xDCE)] public byte     stat_stone;
-    [FieldOffset(0xDD0)] public bool     capture;  // Set to True in MsCalcCommand if command uses weapon properties and attacker has Capture auto-ability
-    [FieldOffset(0xDD1)] public bool     captured; // Set to True on death if capture is True and the monster has a valid capture index
+    [FieldOffset(0xDD0)] public bool     should_try_capture; // Set to true when a capture should be attempted if the current attack kills the monster
+    [FieldOffset(0xDD1)] public bool     captured;           // Set to true when an attempted capture succeeds
     [FieldOffset(0xDD2)] public bool     stat_exist_flag;
     [FieldOffset(0xDD6)] public byte     stat_action;
     [FieldOffset(0xDD7)] public bool     in_ctb_list;


### PR DESCRIPTION
I'm not entirely sure what `battle_type` is. I just named it that based on it disabling most battle rewards when set to a non-zero value