### PR TITLE
Update StNumber, SaveData, Command and PlySave Fields

### DIFF
--- a/core/fh/FFX/Ids/btl.cs
+++ b/core/fh/FFX/Ids/btl.cs
@@ -42,6 +42,7 @@ public static class BtlId {
     public const T_XBtlId BTL_BSIL07_02  = 0x0048_0002;
     public const T_XBtlId BTL_BSIL07_50  = 0x0048_0032;
     public const T_XBtlId BTL_BSIL07_51  = 0x0048_0033;
+    public const T_XBtlId BTL_BSIL07_70  = 0x0048_0046;
 
     // bsil04
     public const T_XBtlId BTL_BSIL04_00  = 0x0045_0000;
@@ -149,6 +150,7 @@ public static class BtlId {
     public const T_XBtlId BTL_KINO00_04  = 0x00DC_0004;
     public const T_XBtlId BTL_KINO00_05  = 0x00DC_0005;
     public const T_XBtlId BTL_KINO00_06  = 0x00DC_0006;
+    public const T_XBtlId BTL_KINO00_70  = 0x00DC_0046;
 
     // kino01
     public const T_XBtlId BTL_KINO01_00  = 0x00DD_0000;
@@ -158,6 +160,9 @@ public static class BtlId {
     public const T_XBtlId BTL_KINO01_04  = 0x00DD_0004;
     public const T_XBtlId BTL_KINO01_05  = 0x00DD_0005;
     public const T_XBtlId BTL_KINO01_06  = 0x00DD_0006;
+    public const T_XBtlId BTL_KINO01_70  = 0x00DD_0046;
+    public const T_XBtlId BTL_KINO01_71  = 0x00DD_0047;
+    public const T_XBtlId BTL_KINO01_72  = 0x00DD_0048;
 
     // kino05
     public const T_XBtlId BTL_KINO05_00  = 0x00E1_0000;
@@ -168,6 +173,8 @@ public static class BtlId {
     public const T_XBtlId BTL_KINO05_05  = 0x00E1_0005;
     public const T_XBtlId BTL_KINO05_06  = 0x00E1_0006;
     public const T_XBtlId BTL_KINO05_07  = 0x00E1_0007;
+    public const T_XBtlId BTL_KINO05_70  = 0x00E1_0046;
+    public const T_XBtlId BTL_KINO05_71  = 0x00E1_0047;
 
     // kino02
     public const T_XBtlId BTL_KINO02_00  = 0x00DE_0000;
@@ -238,6 +245,8 @@ public static class BtlId {
     public const T_XBtlId BTL_KAMI03_05  = 0x012F_0005;
     public const T_XBtlId BTL_KAMI03_06  = 0x012F_0006;
     public const T_XBtlId BTL_KAMI03_07  = 0x012F_0007;
+    public const T_XBtlId BTL_KAMI03_70  = 0x012F_0046;
+    public const T_XBtlId BTL_KAMI03_71  = 0x012F_0047;
 
     // mcfr00
     public const T_XBtlId BTL_MCFR00_00  = 0x0136_0000;
@@ -265,6 +274,7 @@ public static class BtlId {
     public const T_XBtlId BTL_MCYT00_20  = 0x0154_0014;
     public const T_XBtlId BTL_MCYT00_21  = 0x0154_0015;
     public const T_XBtlId BTL_MCYT00_22  = 0x0154_0016;
+    public const T_XBtlId BTL_MCYT00_70  = 0x0154_0046;
 
     // maca03
     public const T_XBtlId BTL_MACA03_00  = 0x014D_0000;
@@ -327,6 +337,7 @@ public static class BtlId {
     public const T_XBtlId BTL_BIKA03_30  = 0x0161_001E;
     public const T_XBtlId BTL_BIKA03_31  = 0x0161_001F;
     public const T_XBtlId BTL_BIKA03_32  = 0x0161_0020;
+    public const T_XBtlId BTL_BIKA03_70  = 0x0161_0046;
 
     // azit03
     public const T_XBtlId BTL_AZIT03_00  = 0x016B_0000;
@@ -341,6 +352,7 @@ public static class BtlId {
 
     // hiku15
     public const T_XBtlId BTL_HIKU15_00  = 0x018B_0000;
+    public const T_XBtlId BTL_HIKU15_70  = 0x018B_0046;
 
     // bvyt00
     public const T_XBtlId BTL_BVYT00_00  = 0x019A_0000;
@@ -445,6 +457,11 @@ public static class BtlId {
     public const T_XBtlId BTL_NAGI05_24  = 0x01AE_0018;
     public const T_XBtlId BTL_NAGI05_25  = 0x01AE_0019;
     public const T_XBtlId BTL_NAGI05_50  = 0x01AE_0032;
+    public const T_XBtlId BTL_NAGI05_70  = 0x01AE_0046;
+    public const T_XBtlId BTL_NAGI05_71  = 0x01AE_0047;
+    public const T_XBtlId BTL_NAGI05_72  = 0x01AE_0048;
+    public const T_XBtlId BTL_NAGI05_73  = 0x01AE_0049;
+    public const T_XBtlId BTL_NAGI05_74  = 0x01AE_004A;
 
     // mtgz01
     public const T_XBtlId BTL_MTGZ01_00  = 0x01E6_0000;
@@ -454,6 +471,7 @@ public static class BtlId {
     public const T_XBtlId BTL_MTGZ01_04  = 0x01E6_0004;
     public const T_XBtlId BTL_MTGZ01_05  = 0x01E6_0005;
     public const T_XBtlId BTL_MTGZ01_10  = 0x01E6_000A;
+    public const T_XBtlId BTL_MTGZ01_70  = 0x01E6_0046;
 
     // mtgz02
     public const T_XBtlId BTL_MTGZ02_00  = 0x01E7_0000;
@@ -496,6 +514,7 @@ public static class BtlId {
 
     // dome06
     public const T_XBtlId BTL_DOME06_00  = 0x0209_0000;
+    public const T_XBtlId BTL_DOME06_70  = 0x0209_0046;
 
     // ssbt00
     public const T_XBtlId BTL_SSBT00_00  = 0x0235_0000;

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -69,36 +69,36 @@ public struct Command {
     private bool uses_f2      { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
     public  bool uses_cursor { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } // If false, cursor is invisible
 
-    public  bool is_usable_outside_combat { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }
-    public  bool is_usable_in_combat      { readonly get { return flags_misc.get_bit ( 1);    } set { flags_misc.set_bit ( 1,    value); } }
-    public  bool display_move_name        { readonly get { return flags_misc.get_bit ( 2);    } set { flags_misc.set_bit ( 2,    value); } }
-    public  uint accuracy_formula         { readonly get { return flags_misc.get_bits( 3, 3); } set { flags_misc.set_bits( 3, 3, value); } }
-    public  bool is_affected_by_darkness  { readonly get { return flags_misc.get_bit ( 6);    } set { flags_misc.set_bit ( 6,    value); } }
-    public  bool is_affected_by_reflect   { readonly get { return flags_misc.get_bit ( 7);    } set { flags_misc.set_bit ( 7,    value); } }
-    public  bool absorbs_dmg              { readonly get { return flags_misc.get_bit ( 8);    } set { flags_misc.set_bit ( 8,    value); } }
-    public  bool steals_item              { readonly get { return flags_misc.get_bit ( 9);    } set { flags_misc.set_bit ( 9,    value); } }
-    public  bool is_in_use_menu           { readonly get { return flags_misc.get_bit (10);    } set { flags_misc.set_bit (10,    value); } }
-    public  bool is_in_sub_menu           { readonly get { return flags_misc.get_bit (11);    } set { flags_misc.set_bit (11,    value); } }
-    public  bool is_in_trigger_menu       { readonly get { return flags_misc.get_bit (12);    } set { flags_misc.set_bit (12,    value); } }
-    public  bool inflicts_delay_weak      { readonly get { return flags_misc.get_bit (13);    } set { flags_misc.set_bit (13,    value); } }
-    public  bool inflicts_delay_strong    { readonly get { return flags_misc.get_bit (14);    } set { flags_misc.set_bit (14,    value); } }
-    public  bool targets_randomly         { readonly get { return flags_misc.get_bit (15);    } set { flags_misc.set_bit (15,    value); } }
-    public  bool is_piercing              { readonly get { return flags_misc.get_bit (16);    } set { flags_misc.set_bit (16,    value); } }
-    public  bool is_affected_by_silence   { readonly get { return flags_misc.get_bit (17);    } set { flags_misc.set_bit (17,    value); } }
-    public  bool uses_weapon_properties   { readonly get { return flags_misc.get_bit (18);    } set { flags_misc.set_bit (18,    value); } }
-    public  bool is_trigger_command       { readonly get { return flags_misc.get_bit (19);    } set { flags_misc.set_bit (19,    value); } }
-    public  bool uses_tier1_cast_anim     { readonly get { return flags_misc.get_bit (20);    } set { flags_misc.set_bit (20,    value); } }
-    public  bool uses_tier3_cast_anim     { readonly get { return flags_misc.get_bit (21);    } set { flags_misc.set_bit (21,    value); } }
-    public  bool destroys_user            { readonly get { return flags_misc.get_bit (22);    } set { flags_misc.set_bit (22,    value); } }
-    public  bool misses_living_targets    { readonly get { return flags_misc.get_bit (23);    } set { flags_misc.set_bit (23,    value); } }
-    public  bool charges_limit_gauge      { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } } // If limit mode is Warrior/Healer
-    public  bool empties_limit_gauge      { readonly get { return flags_misc.get_bit (25);    } set { flags_misc.set_bit (25,    value); } }
-    public  bool show_spellcast_aura      { readonly get { return flags_misc.get_bit (26);    } set { flags_misc.set_bit (26,    value); } }
-    public  bool should_run_away          { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } } // Escape & Switch
-    public  bool can_copycat              { readonly get { return flags_misc.get_bit (28);    } set { flags_misc.set_bit (28,    value); } }
-    private bool _anim_f6                 { readonly get { return flags_misc.get_bit (29);    } set { flags_misc.set_bit (29,    value); } }
-    public  bool is_aeon_limit            { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } } // Only set on Aeon Overdrives
-    public  bool is_bribe                 { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } } // Enemy runs off?
+    public  bool is_usable_outside_combat  { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }
+    public  bool is_usable_in_combat       { readonly get { return flags_misc.get_bit ( 1);    } set { flags_misc.set_bit ( 1,    value); } }
+    public  bool display_move_name         { readonly get { return flags_misc.get_bit ( 2);    } set { flags_misc.set_bit ( 2,    value); } }
+    public  uint accuracy_formula          { readonly get { return flags_misc.get_bits( 3, 3); } set { flags_misc.set_bits( 3, 3, value); } }
+    public  bool is_affected_by_darkness   { readonly get { return flags_misc.get_bit ( 6);    } set { flags_misc.set_bit ( 6,    value); } }
+    public  bool is_affected_by_reflect    { readonly get { return flags_misc.get_bit ( 7);    } set { flags_misc.set_bit ( 7,    value); } }
+    public  bool absorbs_dmg               { readonly get { return flags_misc.get_bit ( 8);    } set { flags_misc.set_bit ( 8,    value); } }
+    public  bool steals_item               { readonly get { return flags_misc.get_bit ( 9);    } set { flags_misc.set_bit ( 9,    value); } }
+    public  bool is_in_use_menu            { readonly get { return flags_misc.get_bit (10);    } set { flags_misc.set_bit (10,    value); } }
+    public  bool is_in_sub_menu            { readonly get { return flags_misc.get_bit (11);    } set { flags_misc.set_bit (11,    value); } }
+    public  bool is_in_trigger_menu        { readonly get { return flags_misc.get_bit (12);    } set { flags_misc.set_bit (12,    value); } }
+    public  bool inflicts_delay_weak       { readonly get { return flags_misc.get_bit (13);    } set { flags_misc.set_bit (13,    value); } }
+    public  bool inflicts_delay_strong     { readonly get { return flags_misc.get_bit (14);    } set { flags_misc.set_bit (14,    value); } }
+    public  bool targets_randomly          { readonly get { return flags_misc.get_bit (15);    } set { flags_misc.set_bit (15,    value); } }
+    public  bool is_piercing               { readonly get { return flags_misc.get_bit (16);    } set { flags_misc.set_bit (16,    value); } }
+    public  bool is_affected_by_silence    { readonly get { return flags_misc.get_bit (17);    } set { flags_misc.set_bit (17,    value); } }
+    public  bool uses_weapon_properties    { readonly get { return flags_misc.get_bit (18);    } set { flags_misc.set_bit (18,    value); } }
+    public  bool is_trigger_command        { readonly get { return flags_misc.get_bit (19);    } set { flags_misc.set_bit (19,    value); } }
+    public  bool uses_tier1_cast_anim      { readonly get { return flags_misc.get_bit (20);    } set { flags_misc.set_bit (20,    value); } }
+    public  bool uses_tier3_cast_anim      { readonly get { return flags_misc.get_bit (21);    } set { flags_misc.set_bit (21,    value); } }
+    public  bool destroys_user             { readonly get { return flags_misc.get_bit (22);    } set { flags_misc.set_bit (22,    value); } }
+    public  bool misses_living_targets     { readonly get { return flags_misc.get_bit (23);    } set { flags_misc.set_bit (23,    value); } }
+    public  bool charges_limit_gauge       { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } } // If limit mode is Warrior/Healer
+    public  bool empties_limit_gauge       { readonly get { return flags_misc.get_bit (25);    } set { flags_misc.set_bit (25,    value); } }
+    public  bool show_user_casting_effects { readonly get { return flags_misc.get_bit (26);    } set { flags_misc.set_bit (26,    value); } }
+    public  bool should_run_away           { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } } // Escape & Switch
+    public  bool can_copycat               { readonly get { return flags_misc.get_bit (28);    } set { flags_misc.set_bit (28,    value); } }
+    private bool _anim_f6                  { readonly get { return flags_misc.get_bit (29);    } set { flags_misc.set_bit (29,    value); } }
+    public  bool is_aeon_limit             { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } } // Only set on Aeon Overdrives
+    public  bool is_bribe                  { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } } // Enemy runs off?
 
     public bool deals_physical_damage       { readonly get { return flags_damage.get_bit(0); } set { flags_damage.set_bit(0, value); } }
     public bool deals_magical_damage        { readonly get { return flags_damage.get_bit(1); } set { flags_damage.set_bit(1, value); } }

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -28,7 +28,7 @@ public struct Command {
     [FieldOffset(0x18)] public  byte              sub_menu_cat;
     [FieldOffset(0x19)] public  byte              user_id;
     [FieldOffset(0x1A)] public  byte              flags_target;
-    [FieldOffset(0x1B)] public  byte              flags_use; //better name for this?
+    [FieldOffset(0x1B)] public  byte              flags_use;
     [FieldOffset(0x1C)] public  uint              flags_misc;
     [FieldOffset(0x20)] public  byte              flags_damage;
     [FieldOffset(0x21)] public  bool              steals_gil;
@@ -53,7 +53,7 @@ public struct Command {
     [FieldOffset(0x5A)] public  byte              flags_buffs_mix;
 
     public  bool is_top_level_in_menu { get { return flags_menu.get_bit(0); } set { flags_menu.set_bit (0, value); } }
-    private bool _menu_f4             { get { return flags_menu.get_bit(3); } set { flags_menu.set_bit (3, value); } } //Only on Skill, Special, Blk/Wht Magic
+    private bool _menu_f4             { get { return flags_menu.get_bit(3); } set { flags_menu.set_bit (3, value); } } // Only used on Skill, Special, Blk/Wht Magic
     public  bool opens_sub_menu       { get { return flags_menu.get_bit(4); } set { flags_menu.set_bit (4, value); } }
 
     public  bool can_target        { readonly get { return flags_target.get_bit(0); } set { flags_target.set_bit(0, value); } }
@@ -65,9 +65,9 @@ public struct Command {
     public  bool targets_dead      { readonly get { return flags_target.get_bit(6); } set { flags_target.set_bit(6, value); } }
     private bool _targets_f8       { readonly get { return flags_target.get_bit(7); } set { flags_target.set_bit(7, value); } }
 
-    public  bool use_long_range { readonly get { return flags_use.get_bit(0); } set { flags_use.set_bit(0, value); } } //Command can be used at long range
-    private bool use_f2         { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
-    public  bool use_cursor     { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } //If 0, cursor is invisible
+    public  bool is_ranged   { readonly get { return flags_use.get_bit(0); } set { flags_use.set_bit(0, value); } } // Command can be used at long range
+    private bool uses_f2      { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
+    public  bool uses_cursor { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } // If false, cursor is invisible
 
     public  bool is_usable_outside_combat { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }
     public  bool is_usable_in_combat      { readonly get { return flags_misc.get_bit ( 1);    } set { flags_misc.set_bit ( 1,    value); } }
@@ -91,14 +91,14 @@ public struct Command {
     public  bool uses_tier3_cast_anim     { readonly get { return flags_misc.get_bit (21);    } set { flags_misc.set_bit (21,    value); } }
     public  bool destroys_user            { readonly get { return flags_misc.get_bit (22);    } set { flags_misc.set_bit (22,    value); } }
     public  bool misses_living_targets    { readonly get { return flags_misc.get_bit (23);    } set { flags_misc.set_bit (23,    value); } }
-    public  bool charges_limit_gauge      { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } } //If limit mode is Warrior/Healer
+    public  bool charges_limit_gauge      { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } } // If limit mode is Warrior/Healer
     public  bool empties_limit_gauge      { readonly get { return flags_misc.get_bit (25);    } set { flags_misc.set_bit (25,    value); } }
     public  bool show_spellcast_aura      { readonly get { return flags_misc.get_bit (26);    } set { flags_misc.set_bit (26,    value); } }
-    public  bool user_runs_off            { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } } //Escape
+    public  bool should_run_away          { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } } // Escape & Switch
     public  bool can_copycat              { readonly get { return flags_misc.get_bit (28);    } set { flags_misc.set_bit (28,    value); } }
     private bool _anim_f6                 { readonly get { return flags_misc.get_bit (29);    } set { flags_misc.set_bit (29,    value); } }
-    public  bool aeon_limit               { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } } //Only set on Aeon Overdrives
-    public  bool bribe                    { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } } //Enemy runs off?
+    public  bool is_aeon_limit            { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } } // Only set on Aeon Overdrives
+    public  bool is_bribe                 { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } } // Enemy runs off?
 
     public bool deals_physical_damage       { readonly get { return flags_damage.get_bit(0); } set { flags_damage.set_bit(0, value); } }
     public bool deals_magical_damage        { readonly get { return flags_damage.get_bit(1); } set { flags_damage.set_bit(1, value); } }

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -66,7 +66,7 @@ public struct Command {
     private bool _targets_f8       { readonly get { return flags_target.get_bit(7); } set { flags_target.set_bit(7, value); } }
 
     public  bool is_ranged   { readonly get { return flags_use.get_bit(0); } set { flags_use.set_bit(0, value); } } // Command can be used at long range
-    private bool uses_f2      { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
+    private bool uses_f2     { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
     public  bool uses_cursor { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } // If false, cursor is invisible
 
     public  bool is_usable_outside_combat  { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -65,9 +65,9 @@ public struct Command {
     public  bool targets_dead      { readonly get { return flags_target.get_bit(6); } set { flags_target.set_bit(6, value); } }
     private bool _targets_f8       { readonly get { return flags_target.get_bit(7); } set { flags_target.set_bit(7, value); } }
 
-    public  bool is_ranged   { readonly get { return flags_use.get_bit(0); } set { flags_use.set_bit(0, value); } } // Command can be used at long range
-    private bool uses_f2     { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
-    public  bool uses_cursor { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } // If false, cursor is invisible
+    public  bool is_ranged   { readonly get { return flags_usage.get_bit(0); } set { flags_usage.set_bit(0, value); } } // Command can be used at long range
+    private bool uses_f2     { readonly get { return flags_usage.get_bit(1); } set { flags_usage.set_bit(1, value); } }
+    public  bool uses_cursor { readonly get { return flags_usage.get_bit(2); } set { flags_usage.set_bit(2, value); } } // If false, cursor is invisible
 
     public  bool is_usable_outside_combat  { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }
     public  bool is_usable_in_combat       { readonly get { return flags_misc.get_bit ( 1);    } set { flags_misc.set_bit ( 1,    value); } }

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -28,7 +28,7 @@ public struct Command {
     [FieldOffset(0x18)] public  byte              sub_menu_cat;
     [FieldOffset(0x19)] public  byte              user_id;
     [FieldOffset(0x1A)] public  byte              flags_target;
-    [FieldOffset(0x1B)] public  byte              flags_use;
+    [FieldOffset(0x1B)] public  byte              flags_usage;
     [FieldOffset(0x1C)] public  uint              flags_misc;
     [FieldOffset(0x20)] public  byte              flags_damage;
     [FieldOffset(0x21)] public  bool              steals_gil;
@@ -108,6 +108,15 @@ public struct Command {
     public bool is_cleanse                  { readonly get { return flags_damage.get_bit(5); } set { flags_damage.set_bit(5, value); } }
     public bool ignores_break_damage_limit  { readonly get { return flags_damage.get_bit(6); } set { flags_damage.set_bit(6, value); } }
     public bool innate_break_damage_limit   { readonly get { return flags_damage.get_bit(7); } set { flags_damage.set_bit(7, value); } }
+
+    public bool party_preview_enabled       { readonly get { return party_preview.get_bit(0); } set { party_preview.set_bit(0, value); } }
+    public bool party_preview_mp            { readonly get { return party_preview.get_bit(1); } set { party_preview.set_bit(1, value); } }
+    public bool party_preview_status        { readonly get { return party_preview.get_bit(2); } set { party_preview.set_bit(2, value); } }
+    public bool party_preview_world_map     { readonly get { return party_preview.get_bit(3); } set { party_preview.set_bit(3, value); } }
+    public bool party_preview_rename_card_1 { readonly get { return party_preview.get_bit(4); } set { party_preview.set_bit(4, value); } }
+    public bool party_preview_sphere        { readonly get { return party_preview.get_bit(5); } set { party_preview.set_bit(5, value); } }
+    public bool party_preview_hp            { readonly get { return party_preview.get_bit(6); } set { party_preview.set_bit(6, value); } }
+    public bool party_preview_rename_card_2 { readonly get { return party_preview.get_bit(7); } set { party_preview.set_bit(7, value); } }
 
     public bool damages_hp  { readonly get { return flags_damage_class.get_bit(0); } set { flags_damage_class.set_bit(0, value); } }
     public bool damages_mp  { readonly get { return flags_damage_class.get_bit(1); } set { flags_damage_class.set_bit(1, value); } }

--- a/core/fh/FFX/command.cs
+++ b/core/fh/FFX/command.cs
@@ -28,10 +28,11 @@ public struct Command {
     [FieldOffset(0x18)] public  byte              sub_menu_cat;
     [FieldOffset(0x19)] public  byte              user_id;
     [FieldOffset(0x1A)] public  byte              flags_target;
+    [FieldOffset(0x1B)] public  byte              flags_use; //better name for this?
     [FieldOffset(0x1C)] public  uint              flags_misc;
     [FieldOffset(0x20)] public  byte              flags_damage;
     [FieldOffset(0x21)] public  bool              steals_gil;
-    [FieldOffset(0x22)] public  bool              has_party_preview;
+    [FieldOffset(0x22)] public  byte              party_preview;
     [FieldOffset(0x23)] public  byte              flags_damage_class;
     [FieldOffset(0x24)] public  byte              ctb_rank;
     [FieldOffset(0x25)] public  byte              mp_cost;
@@ -46,13 +47,13 @@ public struct Command {
     [FieldOffset(0x2E)] public  StatusMap         status_map;
     [FieldOffset(0x47)] public  StatusDurationMap status_duration_map;
     [FieldOffset(0x54)] public  StatusExtraFlags  flags_status_extra;
+    [FieldOffset(0x56)] public  byte              flags_buffs_stat;
     [FieldOffset(0x58)] public  byte              overdrive_category;
     [FieldOffset(0x59)] public  byte              buff_amount;
     [FieldOffset(0x5A)] public  byte              flags_buffs_mix;
-    [FieldOffset(0x56)] public  byte              flags_buffs_stat;
 
     public  bool is_top_level_in_menu { get { return flags_menu.get_bit(0); } set { flags_menu.set_bit (0, value); } }
-    private bool _menu_f4             { get { return flags_menu.get_bit(3); } set { flags_menu.set_bit (3, value); } }
+    private bool _menu_f4             { get { return flags_menu.get_bit(3); } set { flags_menu.set_bit (3, value); } } //Only on Skill, Special, Blk/Wht Magic
     public  bool opens_sub_menu       { get { return flags_menu.get_bit(4); } set { flags_menu.set_bit (4, value); } }
 
     public  bool can_target        { readonly get { return flags_target.get_bit(0); } set { flags_target.set_bit(0, value); } }
@@ -63,6 +64,10 @@ public struct Command {
     public  bool targets_team      { readonly get { return flags_target.get_bit(5); } set { flags_target.set_bit(5, value); } }
     public  bool targets_dead      { readonly get { return flags_target.get_bit(6); } set { flags_target.set_bit(6, value); } }
     private bool _targets_f8       { readonly get { return flags_target.get_bit(7); } set { flags_target.set_bit(7, value); } }
+
+    public  bool use_long_range { readonly get { return flags_use.get_bit(0); } set { flags_use.set_bit(0, value); } } //Command can be used at long range
+    private bool use_f2         { readonly get { return flags_use.get_bit(1); } set { flags_use.set_bit(1, value); } }
+    public  bool use_cursor     { readonly get { return flags_use.get_bit(2); } set { flags_use.set_bit(2, value); } } //If 0, cursor is invisible
 
     public  bool is_usable_outside_combat { readonly get { return flags_misc.get_bit ( 0);    } set { flags_misc.set_bit ( 0,    value); } }
     public  bool is_usable_in_combat      { readonly get { return flags_misc.get_bit ( 1);    } set { flags_misc.set_bit ( 1,    value); } }
@@ -86,14 +91,14 @@ public struct Command {
     public  bool uses_tier3_cast_anim     { readonly get { return flags_misc.get_bit (21);    } set { flags_misc.set_bit (21,    value); } }
     public  bool destroys_user            { readonly get { return flags_misc.get_bit (22);    } set { flags_misc.set_bit (22,    value); } }
     public  bool misses_living_targets    { readonly get { return flags_misc.get_bit (23);    } set { flags_misc.set_bit (23,    value); } }
-    private bool _anim_f1                 { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } }
-    private bool _anim_f2                 { readonly get { return flags_misc.get_bit (25);    } set { flags_misc.set_bit (25,    value); } }
-    private bool _anim_f3                 { readonly get { return flags_misc.get_bit (26);    } set { flags_misc.set_bit (26,    value); } }
-    private bool _anim_f4                 { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } }
-    private bool _anim_f5                 { readonly get { return flags_misc.get_bit (28);    } set { flags_misc.set_bit (28,    value); } }
+    public  bool charges_limit_gauge      { readonly get { return flags_misc.get_bit (24);    } set { flags_misc.set_bit (24,    value); } } //If limit mode is Warrior/Healer
+    public  bool empties_limit_gauge      { readonly get { return flags_misc.get_bit (25);    } set { flags_misc.set_bit (25,    value); } }
+    public  bool show_spellcast_aura      { readonly get { return flags_misc.get_bit (26);    } set { flags_misc.set_bit (26,    value); } }
+    public  bool user_runs_off            { readonly get { return flags_misc.get_bit (27);    } set { flags_misc.set_bit (27,    value); } } //Escape
+    public  bool can_copycat              { readonly get { return flags_misc.get_bit (28);    } set { flags_misc.set_bit (28,    value); } }
     private bool _anim_f6                 { readonly get { return flags_misc.get_bit (29);    } set { flags_misc.set_bit (29,    value); } }
-    private bool _anim_f7                 { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } }
-    private bool _anim_f8                 { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } }
+    public  bool aeon_limit               { readonly get { return flags_misc.get_bit (30);    } set { flags_misc.set_bit (30,    value); } } //Only set on Aeon Overdrives
+    public  bool bribe                    { readonly get { return flags_misc.get_bit (31);    } set { flags_misc.set_bit (31,    value); } } //Enemy runs off?
 
     public bool deals_physical_damage       { readonly get { return flags_damage.get_bit(0); } set { flags_damage.set_bit(0, value); } }
     public bool deals_magical_damage        { readonly get { return flags_damage.get_bit(1); } set { flags_damage.set_bit(1, value); } }

--- a/core/fh/FFX/plysave.cs
+++ b/core/fh/FFX/plysave.cs
@@ -47,9 +47,9 @@ public struct PlySave {
     [FieldOffset(0x3E)] public  AbilityMap               abi_map;
     [FieldOffset(0x4A)] public  AutoAbilityEffectsMap    auto_ability_effects;
     [FieldOffset(0x50)] public  uint                     battle_count;
-    [FieldOffset(0x54)] public  uint                     enemies_defeated_count;
-    [FieldOffset(0x58)] public  uint                     death_count;
-    [FieldOffset(0x5C)] public  uint                     limits_charged_count;
+    [FieldOffset(0x54)] public  uint                     enemies_defeated;
+    [FieldOffset(0x58)] public  uint                     deaths;
+    [FieldOffset(0x5C)] public  uint                     limits_charged;
     [FieldOffset(0x60)] public  PlySaveLimitModeCtrArray limit_mode_counters;
     [FieldOffset(0x88)] public  OverdriveModeFlags       obtained_limit_modes;
     [FieldOffset(0x8C)] private uint                     __0x8C;

--- a/core/fh/FFX/plysave.cs
+++ b/core/fh/FFX/plysave.cs
@@ -9,7 +9,7 @@ public struct PlySaveLimitModeCtrArray {
 
 [StructLayout(LayoutKind.Explicit, Pack = 4, Size = 0x94)]
 public struct PlySave {
-    [FieldOffset(0x00)] private uint                     __0x0;
+    [FieldOffset(0x00)] public  uint                     name_offset;
     [FieldOffset(0x04)] public  uint                     base_hp;
     [FieldOffset(0x08)] public  uint                     base_mp;
     [FieldOffset(0x0C)] public  byte                     base_strength;
@@ -20,8 +20,7 @@ public struct PlySave {
     [FieldOffset(0x11)] public  byte                     base_luck;
     [FieldOffset(0x12)] public  byte                     base_evasion;
     [FieldOffset(0x13)] public  byte                     base_accuracy;
-    [FieldOffset(0x14)] private ushort                   __0x14;
-    [FieldOffset(0x16)] private ushort                   __0x16;
+    [FieldOffset(0x14)] public  uint                     total_ap;
     [FieldOffset(0x18)] public  uint                     ap;
     [FieldOffset(0x1C)] public  uint                     hp;
     [FieldOffset(0x20)] public  uint                     mp;
@@ -44,13 +43,13 @@ public struct PlySave {
     [FieldOffset(0x3A)] public  byte                     limit_charge_max;
     [FieldOffset(0x3B)] public  byte                     slv_available;
     [FieldOffset(0x3C)] public  byte                     slv_spent;
-    [FieldOffset(0x3D)] private byte                     __0x3D;
+    [FieldOffset(0x3D)] public  byte                     __0x3D; //Set to 0x17 on aeon death -> Aeon becomes greyed out in summon menu and unselectable
     [FieldOffset(0x3E)] public  AbilityMap               abi_map;
     [FieldOffset(0x4A)] public  AutoAbilityEffectsMap    auto_ability_effects;
     [FieldOffset(0x50)] public  uint                     battle_count;
-    [FieldOffset(0x54)] public  uint                     enemies_defeated;
-    [FieldOffset(0x58)] private uint                     __0x58;
-    [FieldOffset(0x5C)] private uint                     __0x5C;
+    [FieldOffset(0x54)] public  uint                     enemies_defeated_count;
+    [FieldOffset(0x58)] public  uint                     death_count;
+    [FieldOffset(0x5C)] public  uint                     limits_charged_count;
     [FieldOffset(0x60)] public  PlySaveLimitModeCtrArray limit_mode_counters;
     [FieldOffset(0x88)] public  OverdriveModeFlags       obtained_limit_modes;
     [FieldOffset(0x8C)] private uint                     __0x8C;
@@ -75,7 +74,7 @@ public struct PlySave {
     public ushort limit_mode_ctr_ally      { readonly get { return limit_mode_counters[13]; } set { limit_mode_counters[13] = value; } }
     public ushort limit_mode_ctr_sufferer  { readonly get { return limit_mode_counters[14]; } set { limit_mode_counters[14] = value; } }
     public ushort limit_mode_ctr_daredevil { readonly get { return limit_mode_counters[15]; } set { limit_mode_counters[15] = value; } }
-    public ushort limit_mode_ctr_liner     { readonly get { return limit_mode_counters[16]; } set { limit_mode_counters[16] = value; } }
+    public ushort limit_mode_ctr_loner     { readonly get { return limit_mode_counters[16]; } set { limit_mode_counters[16] = value; } }
     public ushort limit_mode_ctr_unused1   { readonly get { return limit_mode_counters[17]; } set { limit_mode_counters[17] = value; } }
     public ushort limit_mode_ctr_unused2   { readonly get { return limit_mode_counters[18]; } set { limit_mode_counters[18] = value; } }
     public ushort limit_mode_ctr_aeons     { readonly get { return limit_mode_counters[19]; } set { limit_mode_counters[19] = value; } }

--- a/core/fh/FFX/plysave.cs
+++ b/core/fh/FFX/plysave.cs
@@ -43,7 +43,7 @@ public struct PlySave {
     [FieldOffset(0x3A)] public  byte                     limit_charge_max;
     [FieldOffset(0x3B)] public  byte                     slv_available;
     [FieldOffset(0x3C)] public  byte                     slv_spent;
-    [FieldOffset(0x3D)] public  byte                     __0x3D; //Set to 0x17 on aeon death -> Aeon becomes greyed out in summon menu and unselectable
+    [FieldOffset(0x3D)] public  byte                     __0x3D; // Set to 0x17 on aeon death -> Aeon becomes greyed out in summon menu and unselectable
     [FieldOffset(0x3E)] public  AbilityMap               abi_map;
     [FieldOffset(0x4A)] public  AutoAbilityEffectsMap    auto_ability_effects;
     [FieldOffset(0x50)] public  uint                     battle_count;

--- a/core/fh/FFX/savedata.cs
+++ b/core/fh/FFX/savedata.cs
@@ -228,11 +228,11 @@ public unsafe struct SaveData {
     [FieldOffset(0x5EC)]  public       bool            soundtrack_type;
     [FieldOffset(0xBEC)]  public       ushort          story_progress;
     [FieldOffset(0xC38)]  public       bool            celestial_mirror_obtained;
-    [FieldOffset(0xC39)]  public       byte            celestials_obtained;
+    [FieldOffset(0xC39)]  public       byte            celestials_obtained; // bitfield
     [FieldOffset(0xC5C)]  public       byte            anima_seals_unlocked;
     [FieldOffset(0xC60)]  public       uint            current_airship_location;
-    [FieldOffset(0xC6C)]  public       byte            celestials_half_powered;
-    [FieldOffset(0xC6D)]  public       byte            celestials_full_powered;
+    [FieldOffset(0xC6C)]  public       byte            celestials_half_powered; // bitfield
+    [FieldOffset(0xC6D)]  public       byte            celestials_full_powered; // bitfield
     [FieldOffset(0xC7B)]  public       byte            optional_aeons_unlocked;
     [FieldOffset(0xC7C)]  public       JechtSphereData jecht_spheres;
     [FieldOffset(0xC81)]  public       ushort          unlocked_airship_destinations;

--- a/core/fh/FFX/savedata.cs
+++ b/core/fh/FFX/savedata.cs
@@ -167,91 +167,97 @@ public unsafe struct SaveData {
     }
 
 
-    [FieldOffset(0x0)]    public       ushort         current_room_id;
-    [FieldOffset(0x2)]    public       ushort         last_room_id;
-    [FieldOffset(0x4)]    public       ushort         now_eventjump_map_no;
-    [FieldOffset(0x6)]    public       ushort         last_eventjump_map_no;
-    [FieldOffset(0x8)]    public       ushort         now_eventjump_map_id;
-    [FieldOffset(0xA)]    public       ushort         last_eventjump_map_id;
-    [FieldOffset(0xC)]    public       byte           current_spawnpoint;
-    [FieldOffset(0xD)]    public       byte           last_spawnpoint;
-    [FieldOffset(0xE)]    public       ushort         atel_save_dic_index;
-    [FieldOffset(0x10)]   public       byte           atel_battle_scene_group;
-    [FieldOffset(0x11)]   public       byte           fade_mode;
-    [FieldOffset(0x12)]   public       byte           fade_time;
-    [FieldOffset(0x13)]   public       byte           battle_status; // bitfield
-    [FieldOffset(0x18)]   public fixed uint           flying_ship_pos[2]; // bitfield
-    [FieldOffset(0x20)]   public       byte           atel_is_push_member;
-    [FieldOffset(0x21)]   public fixed byte           atel_push_frontline[3];
-    [FieldOffset(0x24)]   public       byte           atel_push_party;
-    [FieldOffset(0x28)]   public       byte           is_cam_underwater;
-    [FieldOffset(0x29)]   public       byte           is_map_underwater;
-    [FieldOffset(0x2B)]   public       byte           tk_event_new_game;
-    [FieldOffset(0x2C)]   public fixed uint           affection[8];
-    [FieldOffset(0x4C)]   public fixed uint           affection_room_flags[20]; // bitfield
-    [FieldOffset(0xB4)]   public       ushort         item_map_x; // meaning unknown
-    [FieldOffset(0xB6)]   public       ushort         item_map_y; // meaning unknown
-    [FieldOffset(0xB8)]   public       ushort         saved_current_spawnpoint; // Used when loading save
-    [FieldOffset(0xBA)]   public       ushort         saved_current_room_id;    // Used when loading save
-    [FieldOffset(0xBC)]   public       int            time;
-    [FieldOffset(0xC0)]   public       ushort         saved_current_room_id2; // Never read?
-    [FieldOffset(0xC2)]   public       ushort         saved_last_room_id; // Used when loading save
-    [FieldOffset(0xC4)]   public       ushort         saved_now_eventjump_map_no;
-    [FieldOffset(0xC6)]   public       ushort         saved_last_eventjump_map_no;
-    [FieldOffset(0xC8)]   public       ushort         saved_now_eventjump_map_id;
-    [FieldOffset(0xCA)]   public       ushort         saved_last_eventjump_map_id;
-    [FieldOffset(0xCC)]   public       byte           saved_current_spawnpoint2; // Never read?
-    [FieldOffset(0xCE)]   public       byte           saved_last_spawnpoint; // Used when loading save
-    [FieldOffset(0xD1)]   public       byte           albhed_rikku;
-    [FieldOffset(0xD2)]   public       byte           drop_shadow_mode;
-    [FieldOffset(0xD4)]   public       ushort         atel_force_place_id_value;
-    [FieldOffset(0xD6)]   public       byte           atel_force_place_id;
-    [FieldOffset(0xD7)]   public       byte           atel_water_btl_effect;
-    [FieldOffset(0xD8)]   public       uint           on_memory_movie_file_no;
-    [FieldOffset(0xDC)]   public       uint           on_memory_movie_mode;
-    [FieldOffset(0xE0)]   public       uint           on_memory_movie;
-    [FieldOffset(0xE4)]   public       int            rand_encounter_modifiers;
-    [FieldOffset(0xE8)]   public       ushort         btl_end_tag_always;
-    [FieldOffset(0xEA)]   public       ushort         sphere_monitor;
-    [FieldOffset(0x279)]  public       byte           progression_flags_calm_lands_quest;
-    [FieldOffset(0x287)]  public       byte           progression_flags_belgemine_fight;
-    [FieldOffset(0x28B)]  public       byte           progression_flags_monster_arena_unlock_quest;
-    [FieldOffset(0x2F0)]  public       byte           progression_flags_energy_blast;
-    [FieldOffset(0x300)]  public       byte           progression_flags_remiem_temple;
-    [FieldOffset(0x3BE)]  public       byte           progression_flags_omega_ruins;
-    [FieldOffset(0x3C0)]  public       byte           progression_flags_home;
-    [FieldOffset(0x3F1)]  public       byte           progression_flags_thunder_plains;
-    [FieldOffset(0x3FC)]  public       ushort         lightning_dodging_total_bolts;
-    [FieldOffset(0x3FE)]  public       ushort         lightning_dodging_total_dodges;
-    [FieldOffset(0x400)]  public       ushort         lightning_dodging_highest_consecutive_dodges;
-    [FieldOffset(0x5EC)]  public       bool           soundtrack_type;
-    [FieldOffset(0xBEC)]  public       ushort         story_progress;
-    [FieldOffset(0xC5C)]  public       byte           anima_seals_unlocked;
-    [FieldOffset(0xC60)]  public       uint           current_airship_location;
-    [FieldOffset(0xC7B)]  public       byte           optional_aeons_unlocked;
-    [FieldOffset(0xC7C)]  public       JechtSphereData     jecht_spheres;
-    [FieldOffset(0xC81)]  public       ushort         unlocked_airship_destinations;
-    [FieldOffset(0xC89)]  public       byte           completion_flags_dark_valefor;
-    [FieldOffset(0xC8A)]  public       byte           completion_flags_dark_ifrit;
-    [FieldOffset(0xC8B)]  public       byte           completion_flags_dark_ixion;
-    [FieldOffset(0xC8C)]  public       byte           completion_flags_dark_shiva;
-    [FieldOffset(0xC8D)]  public       byte           completion_flags_dark_bahamut;
-    [FieldOffset(0xC8E)]  public       byte           completion_flags_dark_yojimbo;
-    [FieldOffset(0xC8F)]  public       byte           completion_flags_dark_anima;
-    [FieldOffset(0xC90)]  public       byte           completion_flags_dark_magus_sisters;
-    [FieldOffset(0xC91)]  public       byte           penance_unlock_state;
-    [FieldOffset(0x3D0C)] public       uint           config;
-    [FieldOffset(0x3D10)] public       uint           unlocked_primers;
-    [FieldOffset(0x3D14)] public       uint           battle_count;
-    [FieldOffset(0x3D48)] public       uint           gil;
-    [FieldOffset(0x3D58)] public fixed byte           party_frontline[3];
-    [FieldOffset(0x3D5B)] public fixed byte           party_backline[17];
-    [FieldOffset(0x3D6C)] public       LimitAbilityMap     ability_map_limit;
-    [FieldOffset(0x3DA4)] public       uint           yojimbo_compatibility;
-    [FieldOffset(0x3DA8)] public       uint           yojimbo_type; // unknown size
-    [FieldOffset(0x3DAC)] public       uint           tidus_limit_uses;
-    [FieldOffset(0x3DB0)] public       uint           successful_rikku_steals;
-    [FieldOffset(0x3DB4)] public       uint           bribe_gil_spent;
+    [FieldOffset(0x0)]    public       ushort          current_room_id;
+    [FieldOffset(0x2)]    public       ushort          last_room_id;
+    [FieldOffset(0x4)]    public       ushort          now_eventjump_map_no;
+    [FieldOffset(0x6)]    public       ushort          last_eventjump_map_no;
+    [FieldOffset(0x8)]    public       ushort          now_eventjump_map_id;
+    [FieldOffset(0xA)]    public       ushort          last_eventjump_map_id;
+    [FieldOffset(0xC)]    public       byte            current_spawnpoint;
+    [FieldOffset(0xD)]    public       byte            last_spawnpoint;
+    [FieldOffset(0xE)]    public       ushort          atel_save_dic_index;
+    [FieldOffset(0x10)]   public       byte            atel_battle_scene_group;
+    [FieldOffset(0x11)]   public       byte            fade_mode;
+    [FieldOffset(0x12)]   public       byte            fade_time;
+    [FieldOffset(0x13)]   public       byte            battle_status; // bitfield
+    [FieldOffset(0x18)]   public fixed uint            flying_ship_pos[2]; // bitfield
+    [FieldOffset(0x20)]   public       byte            atel_is_push_member;
+    [FieldOffset(0x21)]   public fixed byte            atel_push_frontline[3];
+    [FieldOffset(0x24)]   public       byte            atel_push_party;
+    [FieldOffset(0x28)]   public       byte            is_cam_underwater;
+    [FieldOffset(0x29)]   public       byte            is_map_underwater;
+    [FieldOffset(0x2B)]   public       byte            tk_event_new_game;
+    [FieldOffset(0x2C)]   public fixed uint            affection[8];
+    [FieldOffset(0x4C)]   public fixed uint            affection_room_flags[20]; // bitfield
+    [FieldOffset(0xB4)]   public       ushort          item_map_x; // meaning unknown
+    [FieldOffset(0xB6)]   public       ushort          item_map_y; // meaning unknown
+    [FieldOffset(0xB8)]   public       ushort          saved_current_spawnpoint; // Used when loading save
+    [FieldOffset(0xBA)]   public       ushort          saved_current_room_id;    // Used when loading save
+    [FieldOffset(0xBC)]   public       int             time;
+    [FieldOffset(0xC0)]   public       ushort          saved_current_room_id2; // Never read?
+    [FieldOffset(0xC2)]   public       ushort          saved_last_room_id; // Used when loading save
+    [FieldOffset(0xC4)]   public       ushort          saved_now_eventjump_map_no;
+    [FieldOffset(0xC6)]   public       ushort          saved_last_eventjump_map_no;
+    [FieldOffset(0xC8)]   public       ushort          saved_now_eventjump_map_id;
+    [FieldOffset(0xCA)]   public       ushort          saved_last_eventjump_map_id;
+    [FieldOffset(0xCC)]   public       byte            saved_current_spawnpoint2; // Never read?
+    [FieldOffset(0xCE)]   public       byte            saved_last_spawnpoint; // Used when loading save
+    [FieldOffset(0xD1)]   public       byte            albhed_rikku;
+    [FieldOffset(0xD2)]   public       byte            drop_shadow_mode;
+    [FieldOffset(0xD4)]   public       ushort          atel_force_place_id_value;
+    [FieldOffset(0xD6)]   public       byte            atel_force_place_id;
+    [FieldOffset(0xD7)]   public       byte            atel_water_btl_effect;
+    [FieldOffset(0xD8)]   public       uint            on_memory_movie_file_no;
+    [FieldOffset(0xDC)]   public       uint            on_memory_movie_mode;
+    [FieldOffset(0xE0)]   public       uint            on_memory_movie;
+    [FieldOffset(0xE4)]   public       int             rand_encounter_modifiers;
+    [FieldOffset(0xE8)]   public       ushort          btl_end_tag_always;
+    [FieldOffset(0xEA)]   public       ushort          sphere_monitor;
+    [FieldOffset(0x279)]  public       byte            progression_flags_calm_lands_quest;
+    [FieldOffset(0x287)]  public       byte            progression_flags_belgemine_fight;
+    [FieldOffset(0x28B)]  public       byte            progression_flags_monster_arena_unlock_quest;
+    [FieldOffset(0x2F0)]  public       byte            progression_flags_energy_blast;
+    [FieldOffset(0x300)]  public       byte            progression_flags_remiem_temple;
+    [FieldOffset(0x337)]  public       byte            luca_controllable_character;
+    [FieldOffset(0x3BE)]  public       byte            progression_flags_omega_ruins;
+    [FieldOffset(0x3C0)]  public       byte            progression_flags_home;
+    [FieldOffset(0x3F1)]  public       byte            progression_flags_thunder_plains;
+    [FieldOffset(0x3FC)]  public       ushort          lightning_dodging_total_bolts;
+    [FieldOffset(0x3FE)]  public       ushort          lightning_dodging_total_dodges;
+    [FieldOffset(0x400)]  public       ushort          lightning_dodging_highest_consecutive_dodges;
+    [FieldOffset(0x5EC)]  public       bool            soundtrack_type;
+    [FieldOffset(0xBEC)]  public       ushort          story_progress;
+    [FieldOffset(0xC38)]  public       bool            celestial_mirror_obtained;
+    [FieldOffset(0xC39)]  public       byte            celestials_obtained;
+    [FieldOffset(0xC5C)]  public       byte            anima_seals_unlocked;
+    [FieldOffset(0xC60)]  public       uint            current_airship_location;
+    [FieldOffset(0xC6C)]  public       byte            celestials_half_powered;
+    [FieldOffset(0xC6D)]  public       byte            celestials_full_powered;
+    [FieldOffset(0xC7B)]  public       byte            optional_aeons_unlocked;
+    [FieldOffset(0xC7C)]  public       JechtSphereData jecht_spheres;
+    [FieldOffset(0xC81)]  public       ushort          unlocked_airship_destinations;
+    [FieldOffset(0xC89)]  public       byte            completion_flags_dark_valefor;
+    [FieldOffset(0xC8A)]  public       byte            completion_flags_dark_ifrit;
+    [FieldOffset(0xC8B)]  public       byte            completion_flags_dark_ixion;
+    [FieldOffset(0xC8C)]  public       byte            completion_flags_dark_shiva;
+    [FieldOffset(0xC8D)]  public       byte            completion_flags_dark_bahamut;
+    [FieldOffset(0xC8E)]  public       byte            completion_flags_dark_yojimbo;
+    [FieldOffset(0xC8F)]  public       byte            completion_flags_dark_anima;
+    [FieldOffset(0xC90)]  public       byte            completion_flags_dark_magus_sisters;
+    [FieldOffset(0xC91)]  public       byte            penance_unlock_state;
+    [FieldOffset(0xCD7)]  public fixed byte            battle_dialog_lines_seen[42];
+    [FieldOffset(0x3D0C)] public       uint            config;
+    [FieldOffset(0x3D10)] public       uint            unlocked_primers;
+    [FieldOffset(0x3D14)] public       uint            battle_count;
+    [FieldOffset(0x3D48)] public       uint            gil;
+    [FieldOffset(0x3D58)] public fixed byte            party_frontline[3];
+    [FieldOffset(0x3D5B)] public fixed byte            party_backline[17];
+    [FieldOffset(0x3D6C)] public       LimitAbilityMap ability_map_limit;
+    [FieldOffset(0x3DA4)] public       uint            yojimbo_compatibility;
+    [FieldOffset(0x3DA8)] public       uint            yojimbo_type; // unknown size
+    [FieldOffset(0x3DAC)] public       uint            tidus_limit_uses;
+    [FieldOffset(0x3DB0)] public       uint            successful_rikku_steals;
+    [FieldOffset(0x3DB4)] public       uint            bribe_gil_spent;
 
     [FieldOffset(0x3DCC)] public EventFlags           event_flags;
     [FieldOffset(0x3ECC)] public InventoryTypes       inventory_ids;

--- a/core/fh/FFX/st_number.cs
+++ b/core/fh/FFX/st_number.cs
@@ -5,7 +5,11 @@ namespace Fahrenheit.FFX;
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x4)]
 public struct StNumber {
-    [FieldOffset(0x0)] public byte  category;   // Can either be a valid <see cref="PlySaveId"> id or submenu id
+    /// <summary>
+    ///     Can either be a valid <see cref="PlySaveId"> id or submenu id
+    /// </summary>
+    [FieldOffset(0x0)] public byte  category;   
+    
     [FieldOffset(0x1)] public byte  type;
     [FieldOffset(0x2)] public short command_id; // Can also be an Aeon id if category is 0x1 (Yuna)
 }

--- a/core/fh/FFX/st_number.cs
+++ b/core/fh/FFX/st_number.cs
@@ -11,5 +11,5 @@ public struct StNumber {
     [FieldOffset(0x0)] public byte  category;   
     
     [FieldOffset(0x1)] public byte  type;
-    [FieldOffset(0x2)] public short command_id; // Can also be an Aeon id if category is 0x1 (Yuna)
+    [FieldOffset(0x2)] public ushort command_id; // Can also be an Aeon id if category is 0x1 (Yuna)
 }

--- a/core/fh/FFX/st_number.cs
+++ b/core/fh/FFX/st_number.cs
@@ -3,9 +3,7 @@ namespace Fahrenheit.FFX;
 // This is likely to get folded into a different file once we figure out what it's for
 [StructLayout(LayoutKind.Explicit, Size = 0x4)]
 public struct StNumber {
-    [FieldOffset(0x0)] public byte __0x0;
-    [FieldOffset(0x1)] public byte __0x1;
-
-    // Can be a command id or some other unknown id if __0x0 == 1
-    [FieldOffset(0x2)] public short __0x2;
+    [FieldOffset(0x0)] public byte  category;     // Can be a character id or menu
+    [FieldOffset(0x1)] public byte  type; 
+    [FieldOffset(0x2)] public short command_name; // Can be a Command id or Aeon id if category is 0x1 (Yuna)
 }

--- a/core/fh/FFX/st_number.cs
+++ b/core/fh/FFX/st_number.cs
@@ -1,9 +1,11 @@
 namespace Fahrenheit.FFX;
 
-// This is likely to get folded into a different file once we figure out what it's for
+/// <summary>
+///     Responsible for displaying commands the player has unlocked in menus.
+/// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x4)]
 public struct StNumber {
-    [FieldOffset(0x0)] public byte  category;     // Can be a character id or menu
-    [FieldOffset(0x1)] public byte  type; 
-    [FieldOffset(0x2)] public short command_name; // Can be a Command id or Aeon id if category is 0x1 (Yuna)
+    [FieldOffset(0x0)] public byte  category;   // Can either be a valid <see cref="PlySaveId"> id or submenu id
+    [FieldOffset(0x1)] public byte  type;
+    [FieldOffset(0x2)] public short command_id; // Can also be an Aeon id if category is 0x1 (Yuna)
 }


### PR DESCRIPTION
StNumber is used to display commands listed in menus, including character and Aeon overdrives.
Updated Command with new flags for party_preview, flags_misc, and added new flags_use field (though the name likely needs some revision)
Added luca_controllable_character, celestial_mirror_obtained, celestials_obtained, celestials_half_powered, celestials_full_powered and battle_dialog_lines_seen fields to SaveData
Fixed "liner" mistake in PlySave & added name_offset and total_ap, death_count and limits_charged_count fields (also changed enemies_defeated to enemies_defeated_count)