### PR TITLE
Fix crash while initializing events by purging 'shortcuts' to common

### DIFF
--- a/core/fh/FFX/events/events.cs
+++ b/core/fh/FFX/events/events.cs
@@ -2,6 +2,4 @@
 
 namespace Fahrenheit.FFX.Events;
 
-public class FhXEvents {
-    public GameLoopEvents GameLoop = FhApi.Events.Common.GameLoop;
-}
+public class FhXEvents { }

--- a/core/fh/FFX2/events/events.cs
+++ b/core/fh/FFX2/events/events.cs
@@ -2,6 +2,4 @@
 
 namespace Fahrenheit.FFX2.Events;
 
-public class FhX2Events {
-    public GameLoopEvents GameLoop = FhApi.Events.Common.GameLoop;
-}
+public class FhX2Events { }


### PR DESCRIPTION
Fixes #117.