### PR TITLE
Specify the proper Fahrenheit version in its accompanying SDK

### DIFF
--- a/src/sdk/Sdk/Sdk.props
+++ b/src/sdk/Sdk/Sdk.props
@@ -16,7 +16,7 @@
 
     <!-- FAHRENHEIT PACKAGE IMPORT -->
     <ItemGroup>
-        <PackageReference Include="Fahrenheit" Version="1.0.0-alpha08" >
+        <PackageReference Include="Fahrenheit" Version="1.0.0-alpha10" >
             <Private>false</Private>
             <ExcludeAssets>runtime;native</ExcludeAssets>
         </PackageReference>


### PR DESCRIPTION
Closes #149.