### PR TITLE
Print out Source Link version at boot

### DIFF
--- a/src/core/bootloader.cs
+++ b/src/core/bootloader.cs
@@ -140,8 +140,10 @@ internal sealed class FhLoader {
     private readonly Dictionary<string, FhLoadContext> _load_contexts = [];
 
     internal FhLoader() {
-        // Loading the core libraries into ALC.Default ensures they do not 'leak' into plugins' load contexts, causing type identity mismatches.
-        AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Join(FhEnvironment.Finder.Binaries.FullName, "fh.dll"));
+        // Loading the core library into ALC.Default ensures it does not 'leak' into plugins' load contexts, causing type identity mismatches.
+        Assembly self = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Join(FhEnvironment.Finder.Binaries.FullName, "fh.dll"));
+        FhInternal.Log.Info($"Fahrenheit {FileVersionInfo.GetVersionInfo(self.Location).ProductVersion}");
+
         // required for Hexa.NET.ImGui's assembly-probing logic
         HexaGen.Runtime.LibraryLoader.CustomLoadFolders.Add(FhEnvironment.Finder.Binaries.FullName);
     }


### PR DESCRIPTION
The Source Link version (generally, the "informational version") is given in the form ``$(Version)+$(SourceRevisionId)``, ex. ``Fahrenheit 1.0.0-alpha11+bfd0d75656f4cf8a94bd01b4d50a0a75202949ec``.

See:
- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#includesourcerevisionininformationalversion
- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#sourcerevisionid
- https://github.com/dotnet/sdk/blob/c4205204e7e5151461d20950c9f957d0ae19ac36/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets#L70
- https://github.com/dotnet/sdk/blob/c4205204e7e5151461d20950c9f957d0ae19ac36/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets#L232

This alone is insufficient to _fully_ identify a Fahrenheit build (since the Source Link version won't update from purely local changes until a commit is made), but at least it's a start.