### PR TITLE
Remove obsolete `FhCall` entries that were made common

### DIFF
--- a/src/core/ffx/call_1.g.cs
+++ b/src/core/ffx/call_1.g.cs
@@ -21356,9 +21356,6 @@ public static unsafe partial class FhCall {
     // unknown undefined GetSingleton() at 005cd190
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
-    // unknown undefined PStreamFile() at 00607d80
-
-    // Symbol skipped (deemed uninterpretable or explicitly rejected):
     // unknown undefined PStream() at 0060f210
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
@@ -21804,9 +21801,6 @@ public static unsafe partial class FhCall {
     // unknown undefined Bind() at 00622d20
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
-    // __stdcall int FixupClusters(PCluster** clusters, int count) at 00623740
-
-    // Symbol skipped (deemed uninterpretable or explicitly rejected):
     // unknown undefined GetApplication() at 00623d50
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
@@ -22102,13 +22096,7 @@ public static unsafe partial class FhCall {
     // unknown undefined isChrDelayedRelease() at 0069b8f0
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
-    // __thiscall PCluster* loadPCluster(ClusterManager* this, char* name) at 0069ba80
-
-    // Symbol skipped (deemed uninterpretable or explicitly rejected):
     // unknown undefined onLoadPCluster() at 0069bcc0
-
-    // Symbol skipped (deemed uninterpretable or explicitly rejected):
-    // __thiscall void releasePCluster(ClusterManager* this, int param_1) at 0069bef0
 
     // Symbol skipped (deemed uninterpretable or explicitly rejected):
     // unknown undefined releasePCluster() at 0069bfd0
@@ -32047,13 +32035,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00625840();
     public static FhMethodHandle<FUN_00625840> h_FUN_00625840 => new( new FhMethodLocation("FFX.exe", 0x225840) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00625930() at 00625930
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00625930();
-    public static FhMethodHandle<FUN_00625930> h_FUN_00625930 => new( new FhMethodLocation("FFX.exe", 0x225930) );
 
     // Original after pruning:
     // unknown undefined FUN_00626c50() at 00626c50

--- a/src/core/ffx/call_2.g.cs
+++ b/src/core/ffx/call_2.g.cs
@@ -20644,13 +20644,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00647e60> h_FUN_00647e60 => new( new FhMethodLocation("FFX.exe", 0x247E60) );
 
     // Original after pruning:
-    // unknown undefined FUN_00647f20() at 00647f20
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00647f20();
-    public static FhMethodHandle<FUN_00647f20> h_FUN_00647f20 => new( new FhMethodLocation("FFX.exe", 0x247F20) );
-
-    // Original after pruning:
     // unknown undefined FUN_00647fc0() at 00647fc0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -29303,13 +29296,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_006ef450> h_FUN_006ef450 => new( new FhMethodLocation("FFX.exe", 0x2EF450) );
 
     // Original after pruning:
-    // unknown undefined FUN_006ef830() at 006ef830
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_006ef830();
-    public static FhMethodHandle<FUN_006ef830> h_FUN_006ef830 => new( new FhMethodLocation("FFX.exe", 0x2EF830) );
-
-    // Original after pruning:
     // unknown undefined FUN_006efff0() at 006efff0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -29329,20 +29315,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_006f03d0();
     public static FhMethodHandle<FUN_006f03d0> h_FUN_006f03d0 => new( new FhMethodLocation("FFX.exe", 0x2F03D0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_006f0470() at 006f0470
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_006f0470();
-    public static FhMethodHandle<FUN_006f0470> h_FUN_006f0470 => new( new FhMethodLocation("FFX.exe", 0x2F0470) );
-
-    // Original after pruning:
-    // unknown undefined FUN_006f0650() at 006f0650
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_006f0650();
-    public static FhMethodHandle<FUN_006f0650> h_FUN_006f0650 => new( new FhMethodLocation("FFX.exe", 0x2F0650) );
 
     // Original after pruning:
     // unknown undefined FUN_006f07b0() at 006f07b0
@@ -34812,20 +34784,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00787410> h_FUN_00787410 => new( new FhMethodLocation("FFX.exe", 0x387410) );
 
     // Original after pruning:
-    // unknown undefined FUN_00787430() at 00787430
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00787430();
-    public static FhMethodHandle<FUN_00787430> h_FUN_00787430 => new( new FhMethodLocation("FFX.exe", 0x387430) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00787450() at 00787450
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00787450();
-    public static FhMethodHandle<FUN_00787450> h_FUN_00787450 => new( new FhMethodLocation("FFX.exe", 0x387450) );
-
-    // Original after pruning:
     // unknown undefined FUN_00787460() at 00787460
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -39640,13 +39598,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00820970();
     public static FhMethodHandle<FUN_00820970> h_FUN_00820970 => new( new FhMethodLocation("FFX.exe", 0x420970) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00820c00() at 00820c00
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00820c00();
-    public static FhMethodHandle<FUN_00820c00> h_FUN_00820c00 => new( new FhMethodLocation("FFX.exe", 0x420C00) );
 
     // Original after pruning:
     // unknown undefined FUN_008218f0() at 008218f0
@@ -45100,13 +45051,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00871960();
     public static FhMethodHandle<FUN_00871960> h_FUN_00871960 => new( new FhMethodLocation("FFX.exe", 0x471960) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00871d10() at 00871d10
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00871d10();
-    public static FhMethodHandle<FUN_00871d10> h_FUN_00871d10 => new( new FhMethodLocation("FFX.exe", 0x471D10) );
 
     // Original after pruning:
     // unknown undefined FUN_00871ed0() at 00871ed0

--- a/src/core/ffx/call_3.g.cs
+++ b/src/core/ffx/call_3.g.cs
@@ -19274,13 +19274,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00647f00> h_FUN_00647f00 => new( new FhMethodLocation("FFX.exe", 0x247F00) );
 
     // Original after pruning:
-    // unknown undefined FUN_006486f0() at 006486f0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_006486f0();
-    public static FhMethodHandle<FUN_006486f0> h_FUN_006486f0 => new( new FhMethodLocation("FFX.exe", 0x2486F0) );
-
-    // Original after pruning:
     // unknown undefined FUN_00649460() at 00649460
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/core/ffx/call_8.g.cs
+++ b/src/core/ffx/call_8.g.cs
@@ -1576,20 +1576,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<SaveDataSetScreenState> h_SaveDataSetScreenState => new( new FhMethodLocation("FFX.exe", 0x248890) );
 
     // Original after pruning:
-    // unknown undefined SaveDataToLoad() at 00648910
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void SaveDataToLoad();
-    public static FhMethodHandle<SaveDataToLoad> h_SaveDataToLoad => new( new FhMethodLocation("FFX.exe", 0x248910) );
-
-    // Original after pruning:
-    // unknown undefined SaveDataToSave() at 00648950
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void SaveDataToSave();
-    public static FhMethodHandle<SaveDataToSave> h_SaveDataToSave => new( new FhMethodLocation("FFX.exe", 0x248950) );
-
-    // Original after pruning:
     // unknown undefined SaveDataUpdateIcon() at 00648ad0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -10354,13 +10340,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<AtelGetSaveDic> h_AtelGetSaveDic => new( new FhMethodLocation("FFX.exe", 0x46C3A0) );
 
     // Original after pruning:
-    // unknown undefined AtelGetSaveDicName() at 0086c3c0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void AtelGetSaveDicName();
-    public static FhMethodHandle<AtelGetSaveDicName> h_AtelGetSaveDicName => new( new FhMethodLocation("FFX.exe", 0x46C3C0) );
-
-    // Original after pruning:
     // unknown undefined AtelGetScenarioFlag() at 0086c400
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -12396,13 +12375,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void TOControlMessageWindowForMenu();
     public static FhMethodHandle<TOControlMessageWindowForMenu> h_TOControlMessageWindowForMenu => new( new FhMethodLocation("FFX.exe", 0x4AB950) );
-
-    // Original after pruning:
-    // unknown undefined TODrawMessageWindow() at 008abce0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void TODrawMessageWindow();
-    public static FhMethodHandle<TODrawMessageWindow> h_TODrawMessageWindow => new( new FhMethodLocation("FFX.exe", 0x4ABCE0) );
 
     // Original after pruning:
     // unknown undefined TODrawMessageWindowForMenu() at 008abdf0

--- a/src/core/ffx2/call_1.g.cs
+++ b/src/core/ffx2/call_1.g.cs
@@ -30779,13 +30779,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_0088fab0> h_FUN_0088fab0 => new( new FhMethodLocation("FFX-2.exe", 0x48FAB0) );
 
     // Original after pruning:
-    // unknown undefined FUN_00890e40() at 00890e40
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00890e40();
-    public static FhMethodHandle<FUN_00890e40> h_FUN_00890e40 => new( new FhMethodLocation("FFX-2.exe", 0x490E40) );
-
-    // Original after pruning:
     // unknown undefined FUN_00890e90() at 00890e90
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -33248,13 +33241,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00ab50f0();
     public static FhMethodHandle<FUN_00ab50f0> h_FUN_00ab50f0 => new( new FhMethodLocation("FFX-2.exe", 0x6B50F0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00ab51e0() at 00ab51e0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00ab51e0();
-    public static FhMethodHandle<FUN_00ab51e0> h_FUN_00ab51e0 => new( new FhMethodLocation("FFX-2.exe", 0x6B51E0) );
 
     // Original after pruning:
     // unknown undefined FUN_00ab6500() at 00ab6500

--- a/src/core/ffx2/call_2.g.cs
+++ b/src/core/ffx2/call_2.g.cs
@@ -4411,13 +4411,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00487a30> h_FUN_00487a30 => new( new FhMethodLocation("FFX-2.exe", 0x87A30) );
 
     // Original after pruning:
-    // unknown undefined FUN_00487b10() at 00487b10
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00487b10();
-    public static FhMethodHandle<FUN_00487b10> h_FUN_00487b10 => new( new FhMethodLocation("FFX-2.exe", 0x87B10) );
-
-    // Original after pruning:
     // unknown undefined FUN_00487b90() at 00487b90
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -4430,13 +4423,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00487c80();
     public static FhMethodHandle<FUN_00487c80> h_FUN_00487c80 => new( new FhMethodLocation("FFX-2.exe", 0x87C80) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00487cb0() at 00487cb0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00487cb0();
-    public static FhMethodHandle<FUN_00487cb0> h_FUN_00487cb0 => new( new FhMethodLocation("FFX-2.exe", 0x87CB0) );
 
     // Original after pruning:
     // unknown undefined FUN_00487d30() at 00487d30
@@ -4507,13 +4493,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00488600();
     public static FhMethodHandle<FUN_00488600> h_FUN_00488600 => new( new FhMethodLocation("FFX-2.exe", 0x88600) );
-
-    // Original after pruning:
-    // unknown undefined FUN_004889c0() at 004889c0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_004889c0();
-    public static FhMethodHandle<FUN_004889c0> h_FUN_004889c0 => new( new FhMethodLocation("FFX-2.exe", 0x889C0) );
 
     // Original after pruning:
     // unknown undefined FUN_00488a90() at 00488a90
@@ -6504,13 +6483,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_0049e7e0> h_FUN_0049e7e0 => new( new FhMethodLocation("FFX-2.exe", 0x9E7E0) );
 
     // Original after pruning:
-    // unknown undefined FUN_0049e880() at 0049e880
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0049e880();
-    public static FhMethodHandle<FUN_0049e880> h_FUN_0049e880 => new( new FhMethodLocation("FFX-2.exe", 0x9E880) );
-
-    // Original after pruning:
     // unknown undefined FUN_0049ea50() at 0049ea50
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -6523,13 +6495,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_0049ead0();
     public static FhMethodHandle<FUN_0049ead0> h_FUN_0049ead0 => new( new FhMethodLocation("FFX-2.exe", 0x9EAD0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0049ed00() at 0049ed00
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0049ed00();
-    public static FhMethodHandle<FUN_0049ed00> h_FUN_0049ed00 => new( new FhMethodLocation("FFX-2.exe", 0x9ED00) );
 
     // Original after pruning:
     // unknown undefined FUN_0049ee00() at 0049ee00
@@ -14925,13 +14890,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_0051c5c0> h_FUN_0051c5c0 => new( new FhMethodLocation("FFX-2.exe", 0x11C5C0) );
 
     // Original after pruning:
-    // unknown undefined FUN_0051c9b0() at 0051c9b0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0051c9b0();
-    public static FhMethodHandle<FUN_0051c9b0> h_FUN_0051c9b0 => new( new FhMethodLocation("FFX-2.exe", 0x11C9B0) );
-
-    // Original after pruning:
     // unknown undefined FUN_0051d1a0() at 0051d1a0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -14944,20 +14902,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_0051d270();
     public static FhMethodHandle<FUN_0051d270> h_FUN_0051d270 => new( new FhMethodLocation("FFX-2.exe", 0x11D270) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0051d310() at 0051d310
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0051d310();
-    public static FhMethodHandle<FUN_0051d310> h_FUN_0051d310 => new( new FhMethodLocation("FFX-2.exe", 0x11D310) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0051d510() at 0051d510
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0051d510();
-    public static FhMethodHandle<FUN_0051d510> h_FUN_0051d510 => new( new FhMethodLocation("FFX-2.exe", 0x11D510) );
 
     // Original after pruning:
     // unknown undefined FUN_0051d7a0() at 0051d7a0
@@ -17170,13 +17114,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_00539640();
     public static FhMethodHandle<FUN_00539640> h_FUN_00539640 => new( new FhMethodLocation("FFX-2.exe", 0x139640) );
-
-    // Original after pruning:
-    // unknown undefined FUN_005396a0() at 005396a0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_005396a0();
-    public static FhMethodHandle<FUN_005396a0> h_FUN_005396a0 => new( new FhMethodLocation("FFX-2.exe", 0x1396A0) );
 
     // Original after pruning:
     // unknown undefined FUN_005396f0() at 005396f0
@@ -24529,13 +24466,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00604ee0> h_FUN_00604ee0 => new( new FhMethodLocation("FFX-2.exe", 0x204EE0) );
 
     // Original after pruning:
-    // unknown undefined FUN_00605150() at 00605150
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00605150();
-    public static FhMethodHandle<FUN_00605150> h_FUN_00605150 => new( new FhMethodLocation("FFX-2.exe", 0x205150) );
-
-    // Original after pruning:
     // unknown undefined FUN_00606100() at 00606100
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -25759,20 +25689,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_0060f4d0();
     public static FhMethodHandle<FUN_0060f4d0> h_FUN_0060f4d0 => new( new FhMethodLocation("FFX-2.exe", 0x20F4D0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0060f4e0() at 0060f4e0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0060f4e0();
-    public static FhMethodHandle<FUN_0060f4e0> h_FUN_0060f4e0 => new( new FhMethodLocation("FFX-2.exe", 0x20F4E0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0060f500() at 0060f500
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0060f500();
-    public static FhMethodHandle<FUN_0060f500> h_FUN_0060f500 => new( new FhMethodLocation("FFX-2.exe", 0x20F500) );
 
     // Original after pruning:
     // unknown undefined FUN_0060f510() at 0060f510
@@ -45354,13 +45270,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00726b60> h_FUN_00726b60 => new( new FhMethodLocation("FFX-2.exe", 0x326B60) );
 
     // Original after pruning:
-    // unknown undefined FUN_00726b80() at 00726b80
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00726b80();
-    public static FhMethodHandle<FUN_00726b80> h_FUN_00726b80 => new( new FhMethodLocation("FFX-2.exe", 0x326B80) );
-
-    // Original after pruning:
     // unknown undefined FUN_00726bc0() at 00726bc0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -46423,13 +46332,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_0072cce0();
     public static FhMethodHandle<FUN_0072cce0> h_FUN_0072cce0 => new( new FhMethodLocation("FFX-2.exe", 0x32CCE0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_0072ce90() at 0072ce90
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_0072ce90();
-    public static FhMethodHandle<FUN_0072ce90> h_FUN_0072ce90 => new( new FhMethodLocation("FFX-2.exe", 0x32CE90) );
 
     // Original after pruning:
     // unknown undefined FUN_0072cf70() at 0072cf70

--- a/src/core/ffx2/call_3.g.cs
+++ b/src/core/ffx2/call_3.g.cs
@@ -2262,13 +2262,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00791a10> h_FUN_00791a10 => new( new FhMethodLocation("FFX-2.exe", 0x391A10) );
 
     // Original after pruning:
-    // unknown undefined FUN_00791d00() at 00791d00
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00791d00();
-    public static FhMethodHandle<FUN_00791d00> h_FUN_00791d00 => new( new FhMethodLocation("FFX-2.exe", 0x391D00) );
-
-    // Original after pruning:
     // unknown undefined FUN_00792290() at 00792290
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -36996,13 +36989,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00ab2610> h_FUN_00ab2610 => new( new FhMethodLocation("FFX-2.exe", 0x6B2610) );
 
     // Original after pruning:
-    // unknown undefined FUN_00ab3020() at 00ab3020
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00ab3020();
-    public static FhMethodHandle<FUN_00ab3020> h_FUN_00ab3020 => new( new FhMethodLocation("FFX-2.exe", 0x6B3020) );
-
-    // Original after pruning:
     // unknown undefined FUN_00ab3280() at 00ab3280
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -41693,13 +41679,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<FUN_00b4e930> h_FUN_00b4e930 => new( new FhMethodLocation("FFX-2.exe", 0x74E930) );
 
     // Original after pruning:
-    // unknown undefined FUN_00b4e9a0() at 00b4e9a0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00b4e9a0();
-    public static FhMethodHandle<FUN_00b4e9a0> h_FUN_00b4e9a0 => new( new FhMethodLocation("FFX-2.exe", 0x74E9A0) );
-
-    // Original after pruning:
     // unknown undefined FUN_00b4eb60() at 00b4eb60
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -46048,13 +46027,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void FUN_004668b0();
     public static FhMethodHandle<FUN_004668b0> h_FUN_004668b0 => new( new FhMethodLocation("FFX-2.exe", 0x668B0) );
-
-    // Original after pruning:
-    // unknown undefined FUN_00488290() at 00488290
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void FUN_00488290();
-    public static FhMethodHandle<FUN_00488290> h_FUN_00488290 => new( new FhMethodLocation("FFX-2.exe", 0x88290) );
 
     // Original after pruning:
     // unknown undefined FUN_00488360() at 00488360

--- a/src/core/ffx2/call_8.g.cs
+++ b/src/core/ffx2/call_8.g.cs
@@ -39427,13 +39427,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<inputClear> h_inputClear => new( new FhMethodLocation("FFX-2.exe", 0x3AE30) );
 
     // Original after pruning:
-    // unknown undefined SaveDataToSave() at 004884d0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void SaveDataToSave();
-    public static FhMethodHandle<SaveDataToSave> h_SaveDataToSave => new( new FhMethodLocation("FFX-2.exe", 0x884D0) );
-
-    // Original after pruning:
     // unknown undefined graphicLockScreenFadeColor() at 00452f80
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -39665,13 +39658,6 @@ public static unsafe partial class FhCall {
     public static FhMethodHandle<SaveDataSetScreenState> h_SaveDataSetScreenState => new( new FhMethodLocation("FFX-2.exe", 0x88420) );
 
     // Original after pruning:
-    // unknown undefined SaveDataToLoad() at 004884a0
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void SaveDataToLoad();
-    public static FhMethodHandle<SaveDataToLoad> h_SaveDataToLoad => new( new FhMethodLocation("FFX-2.exe", 0x884A0) );
-
-    // Original after pruning:
     // unknown undefined CloudSetMenuState() at 0051c5b0
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -39740,13 +39726,6 @@ public static unsafe partial class FhCall {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public unsafe delegate void TkMenuCloseSaveLoadScreen();
     public static FhMethodHandle<TkMenuCloseSaveLoadScreen> h_TkMenuCloseSaveLoadScreen => new( new FhMethodLocation("FFX-2.exe", 0x3693B0) );
-
-    // Original after pruning:
-    // unknown undefined TkMenuJumpToLoadedScene() at 0076ad50
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void TkMenuJumpToLoadedScene();
-    public static FhMethodHandle<TkMenuJumpToLoadedScene> h_TkMenuJumpToLoadedScene => new( new FhMethodLocation("FFX-2.exe", 0x36AD50) );
 
     // Original after pruning:
     // unknown undefined TkMenuPreSave() at 0076b010


### PR DESCRIPTION
Self-explanatory. See `src/core/call.cs`.