### PR TITLE
SDK: autogenerate manifest, use portable symbols, create symbol packages

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -85,12 +85,9 @@ jobs:
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /t:Restore ${{ env.SOLUTION_FILE_PATH }}
 
+      # 11/06/26 - publish is now implicit as part of build
     - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} ${{ env.SOLUTION_FILE_PATH }}
-
-    - name: Publish
-      working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /t:Publish ${{ env.SOLUTION_FILE_PATH }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
         
         <Company>https://github.com/fahrenheit-crew/fahrenheit</Company>
         <Copyright>Copyright © The Fahrenheit contributors</Copyright>
-        <Version>1.0.0-alpha10</Version>
+        <Version>1.0.0-alpha11</Version>
 	</PropertyGroup>
     
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,18 +1,21 @@
-<Project>	
-    
+<Project>
+
     <PropertyGroup>
         <!--
         Makes it such that projects must be explicitly marked packable.
+        This is because only the SDK and base Fahrenheit require packing.
+
+        We want packing to be silently skipped for all other projects as a result.
         -->
-    
+
         <IsPackable>false</IsPackable>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <!--
         Artifact path handling.
         -->
-    
+
         <_FhOutDir Condition="'$(Configuration)'=='Release'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'artifacts', 'deploy', 'rel'))</_FhOutDir>
         <_FhOutDir Condition="'$(Configuration)'=='Debug'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'artifacts', 'deploy', 'dbg'))</_FhOutDir>
         <_FhBaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'artifacts', 'obj', '$(MSBuildProjectName)'))</_FhBaseIntermediateOutputPath>
@@ -21,31 +24,34 @@
         <_FhOutDirMods>$([MSBuild]::NormalizeDirectory('$(_FhOutDir)', 'mods', '$(AssemblyName)'))</_FhOutDirMods>
         <_FhOutDirPkg Condition="'$(Configuration)'=='Release'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'artifacts', 'pkg', 'rel'))</_FhOutDirPkg>
         <_FhOutDirPkg Condition="'$(Configuration)'=='Debug'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'artifacts', 'pkg', 'dbg'))</_FhOutDirPkg>
-      
+
         <PackageOutputPath>$(_FhOutDirPkg)</PackageOutputPath>
         <PublishDir>$(_FhOutDirBin)</PublishDir>
         <BaseOutputPath>$(_FhBaseOutputPath)</BaseOutputPath>
         <BaseIntermediateOutputPath>$(_FhBaseIntermediateOutputPath)</BaseIntermediateOutputPath>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <!--
-        For ease of enabling Source Link, we embed PDBs.
+        We previously used 'embedded' portable PDBs.
+        However, it does not seem as though debuggers can retrieve such symbols
+        automatically, and sometimes not even manually. Instead, we provide portable
+        PDBs, and publish separate symbol packages to NuGet.
         -->
-        
-        <DebugType>embedded</DebugType>
+
+        <DebugType>portable</DebugType>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <!--
         Custom display attributes.
         -->
-        
+
         <Company>https://github.com/fahrenheit-crew/fahrenheit</Company>
         <Copyright>Copyright © The Fahrenheit contributors</Copyright>
         <Version>1.0.0-alpha11</Version>
-	</PropertyGroup>
-    
+    </PropertyGroup>
+
     <PropertyGroup>
         <!--
         NuGet Package Explorer complains if a package is not built 'deterministically'.
@@ -53,9 +59,9 @@
         See https://docs.github.com/en/actions/reference/workflows-and-actions/variables,
         https://github.com/terrafx/terrafx.interop.windows/blob/7d3e679e74be9da3584b4d4c4689e10422cc485f/Directory.Build.props#L44.
         -->
-    
+
         <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
-    
+
     </PropertyGroup>
-    
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,7 @@
         -->
 
         <IsPackable>false</IsPackable>
-    </PropertyGroup>
 
-    <PropertyGroup>
         <!--
         Artifact path handling.
         -->
@@ -29,9 +27,7 @@
         <PublishDir>$(_FhOutDirBin)</PublishDir>
         <BaseOutputPath>$(_FhBaseOutputPath)</BaseOutputPath>
         <BaseIntermediateOutputPath>$(_FhBaseIntermediateOutputPath)</BaseIntermediateOutputPath>
-    </PropertyGroup>
 
-    <PropertyGroup>
         <!--
         We previously used 'embedded' portable PDBs.
         However, it does not seem as though debuggers can retrieve such symbols
@@ -40,9 +36,7 @@
         -->
 
         <DebugType>portable</DebugType>
-    </PropertyGroup>
 
-    <PropertyGroup>
         <!--
         Custom display attributes.
         -->
@@ -50,9 +44,7 @@
         <Company>https://github.com/fahrenheit-crew/fahrenheit</Company>
         <Copyright>Copyright © The Fahrenheit contributors</Copyright>
         <Version>1.0.0-alpha11</Version>
-    </PropertyGroup>
 
-    <PropertyGroup>
         <!--
         NuGet Package Explorer complains if a package is not built 'deterministically'.
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,66 +1,69 @@
-<Project>	
+<Project>
+
     <!-- fkelava 30/09/25 23:05
-    https://github.com/dotnet/sdk/issues/1366 
-    
-    When mods reference a Fahrenheit mod, the Framework Library or the Support Library
-    for either game, they must not copy any of those - or their dependencies - to output alongside them.
-    
-    This is accomplished by structuring a ProjectReference as such:
-    
-    <ProjectReference Include="..\..\core\framework\Fahrenheit.Core.csproj">
+    https://github.com/dotnet/sdk/issues/1366
+
+    Mods must not include any Fahrenheit core or mod libraries in their build output.
+    The SDK ensures this- and so must the user- by structuring <ProjectReference>s as such:
+
+    <ProjectReference Include="...">
         <Private>false</Private>
         <ExcludeAssets>runtime;native</ExcludeAssets>
     </ProjectReference>
-    
-    The problem are transitive dependencies. If a mod references a mod which references e.g.
-    the FF X Support Library, MSBuild will fail to respect the chain of ExcludeAssets tags
-    and the Support Library will be emitted alongside the mod, which is invalid and will cause issues.
-    
-    This target solves that problem.
-    --> 
-	<Target Name="_MakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
-	    <ItemGroup>
-	        <!-- remove the transitive project references and re-add them as non-private project references -->
-	        <ProjectReference Remove="@(_TransitiveProjectReferences)" />
-	        <ProjectReference Include="@(_TransitiveProjectReferences)" Private="False" />
-	    </ItemGroup>
+
+    However, in the transitive case where a mod references a mod, MSBuild will fail to
+    respect the chain of ExcludeAssets tags and emit Fahrenheit libraries alongside
+    the mod, which is invalid and will cause issues. This target solves that problem.
+    -->
+    <Target Name="__FhMakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
+        <ItemGroup>
+            <!-- remove the transitive project references and re-add them as non-private project references -->
+            <ProjectReference Remove="@(_TransitiveProjectReferences)" />
+            <ProjectReference Include="@(_TransitiveProjectReferences)" Private="False" />
+        </ItemGroup>
     </Target>
-    
+
     <!-- fkelava 01/10/25 11:17
     https://github.com/dotnet/sdk/issues/25411
     https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#post-processing-binaries-before-bundling
-    
-    We have a number of large runtime and native deps such as ImGui and TerraFX. It is desirable that they are shared.
 
-    For mods, this is expressed fairly simply. All mods must use <ExcludeAssets>runtime;native</ExcludeAssets>
-    when referencing other Fahrenheit libraries to avoid type mismatches. The loader ensures that each mod
-    is only loaded once, and that the core libraries are all loaded before any mods are. The load order
-    should ensure mods load correctly relative to one another.
+    We have a number of large runtime and native deps. They must be shared.
 
-    .NET typically does not probe anything but trusted framework paths when DLL loading. All other dependencies
-    are inserted into a `.deps.json` file with a path hint. <ExcludeAssets> has the side effect of purging
+    Mods handle this by using <ExcludeAssets>runtime;native</ExcludeAssets>
+    when referencing Fahrenheit core or mod libraries.
+    The loader ensures that each core or mod library is loaded only once.
+
+    .NET probes only trusted framework paths when DLL loading. All other dependencies
+    are given in a `.deps.json` file with a path hint. <ExcludeAssets> purges
     the associated dependency's hint, implicitly demanding that it be loaded before it is required.
-    
+
     This is always true for the usual use case, the plugin framework. For standalone tools
-    this is never true and causes load errors. An alternative, <ExcludeFromSingleFile> is 
+    this is never true and causes load errors. An alternative, <ExcludeFromSingleFile> is
     available, but suffers from two crippling flaws:
-    - it has no effect on <PackageReference>s 
+    - it has no effect on <PackageReference>s
     - it does not exclude transitive runtime and native dependencies of a <ProjectReference>
-    
+
     Until it does, we specify it to get a valid `.deps.json`, then purge shared dep DLLs in this target to simulate its effect.
     -->
-    <Target Name="ExplicitRemoveFromFilesToBundle" BeforeTargets="GenerateSingleFileBundle" DependsOnTargets="PrepareForBundle">
+    <Target Name="__FhExplicitRemoveFromFilesToBundle" BeforeTargets="GenerateSingleFileBundle" DependsOnTargets="PrepareForBundle">
         <Message Text="List of bundle objects before purging: '@(FilesToBundle)'" Importance="High" />
-    
+
         <!--
         To my unfathomable irritation, the only way I've been able to perform this is by regex.
-        -->        
+        -->
         <ItemGroup>
             <FilesToBundle Remove="@(FilesToBundle)" Condition="
-            $([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', 
+            $([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)',
             '\A(?:TerraFX\.Interop\.Windows|Hexa\.NET\.(?:DirectXTex|ImGui|ImGui\.Backends)|HexaGen\.(?:Runtime|Runtime\.COM)|ImGuiImpl|cimgui|DirectXTex)\z'))" />
         </ItemGroup>
-    
+
         <Message Text="List of bundle objects after purging: '@(FilesToBundle)'" Importance="High" />
     </Target>
+
+    <!-- fkelava 09/06/26 17:36
+    A placeholder target to force publishing to occur after a build.
+    Publishing places build output in its proper place.
+    -->
+    <Target Name="__FhPublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" />
+
 </Project>

--- a/Fahrenheit.slnx
+++ b/Fahrenheit.slnx
@@ -7,6 +7,8 @@
   </Configurations>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
     <File Path="README.md" />
     <File Path="THIRD-PARTY-NOTICES" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ The knowledge gathered by the project underpins many tools and mods for the game
 Fahrenheit, like all of these tools, is free for you to analyze, improve, learn from and use- now and forever.
 
 ## Cloning, building from source and testing
-Fahrenheit includes submodules. To clone them all, use
-``git clone --recurse-submodules https://github.com/fahrenheit-crew/fahrenheit``.
-
 Ensure the folder you cloned to does not contain special characters. This can cause build errors.
 
 Building **requires** Visual Studio 2026 (full IDE or Build Tools only) with the following workloads:
@@ -34,9 +31,8 @@ To build at a Developer PowerShell:
 ```
 msbuild .\Fahrenheit.slnx /t:Restore /p:Configuration=Release
 msbuild .\Fahrenheit.slnx /p:Configuration=Release
-msbuild .\Fahrenheit.slnx /t:Publish /p:Configuration=Release
 ```
-If using Visual Studio, `Build Solution` performs the first two steps for you.
+If using Visual Studio, `Build Solution` performs everything for you.
 For a Debug build, change the `Configuration` parameter to `Debug`.
 
 To install/test your development build:

--- a/src/core/Fahrenheit.csproj
+++ b/src/core/Fahrenheit.csproj
@@ -14,6 +14,8 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/fahrenheit-crew/fahrenheit.git</RepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <!-- PACKAGING EXTRA FILES -->
@@ -59,7 +61,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
-
 
     <!-- NATIVE SOURCE GENERATION FILES -->
     <ItemGroup>

--- a/src/sdk/Sdk/Sdk.props
+++ b/src/sdk/Sdk/Sdk.props
@@ -22,11 +22,6 @@
         </PackageReference>
     </ItemGroup>
 
-    <!-- ASSETS: MANIFEST -->
-    <ItemGroup>
-        <None Include="$(AssemblyName).manifest.json" CopyToOutputDirectory="Always" />
-    </ItemGroup>
-
     <!-- ASSETS: LOCALIZATION -->
     <ItemGroup>
         <None Remove="lang/**" />

--- a/src/sdk/Sdk/Sdk.props
+++ b/src/sdk/Sdk/Sdk.props
@@ -11,7 +11,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RuntimeIdentifier>win-x86</RuntimeIdentifier>
         <EnableDynamicLoading>true</EnableDynamicLoading>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
 
     <!-- FAHRENHEIT PACKAGE IMPORT -->

--- a/src/sdk/Sdk/Sdk.props
+++ b/src/sdk/Sdk/Sdk.props
@@ -16,7 +16,7 @@
 
     <!-- FAHRENHEIT PACKAGE IMPORT -->
     <ItemGroup>
-        <PackageReference Include="Fahrenheit" Version="1.0.0-alpha10" >
+        <PackageReference Include="Fahrenheit" Version="1.0.0-alpha11" >
             <Private>false</Private>
             <ExcludeAssets>runtime;native</ExcludeAssets>
         </PackageReference>

--- a/src/sdk/Sdk/Sdk.targets
+++ b/src/sdk/Sdk/Sdk.targets
@@ -4,65 +4,30 @@
     <!-- fkelava 30/09/25 23:05
     https://github.com/dotnet/sdk/issues/1366
 
-    When mods reference a Fahrenheit mod, the Framework Library or the Support Library
-    for either game, they must not copy any of those - or their dependencies - to output alongside them.
+    Mods must not include any Fahrenheit core or mod libraries in their build output.
+    The SDK ensures this- and so must the user- by structuring <ProjectReference>s as such:
 
-    This is accomplished by structuring a ProjectReference as such:
-
-    <ProjectReference Include="..\..\core\framework\Fahrenheit.Core.csproj">
+    <ProjectReference Include="...">
         <Private>false</Private>
         <ExcludeAssets>runtime;native</ExcludeAssets>
     </ProjectReference>
 
-    The problem are transitive dependencies. If a mod references a mod which references e.g.
-    the FF X Support Library, MSBuild will fail to respect the chain of ExcludeAssets tags
-    and the Support Library will be emitted alongside the mod, which is invalid and will cause issues.
-
-    This target solves that problem.
+    However, in the transitive case where a mod references a mod, MSBuild will fail to
+    respect the chain of ExcludeAssets tags and emit Fahrenheit libraries alongside
+    the mod, which is invalid and will cause issues. This target solves that problem.
     -->
-	<Target Name="_MakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
-	    <ItemGroup>
-	        <!-- remove the transitive project references and re-add them as non-private project references -->
-	        <ProjectReference Remove="@(_TransitiveProjectReferences)" />
-	        <ProjectReference Include="@(_TransitiveProjectReferences)" Private="False" />
-	    </ItemGroup>
-    </Target>
-
-    <!-- fkelava 01/10/25 11:17
-    https://github.com/dotnet/sdk/issues/25411
-    https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#post-processing-binaries-before-bundling
-
-    We have a number of large runtime and native deps such as ImGui and TerraFX. It is desirable that they are shared.
-
-    For mods, this is expressed fairly simply. All mods must use <ExcludeAssets>runtime;native</ExcludeAssets>
-    when referencing other Fahrenheit libraries to avoid type mismatches. The loader ensures that each mod
-    is only loaded once, and that the core libraries are all loaded before any mods are. The load order
-    should ensure mods load correctly relative to one another.
-
-    .NET typically does not probe anything but trusted framework paths when DLL loading. All other dependencies
-    are inserted into a `.deps.json` file with a path hint. <ExcludeAssets> has the side effect of purging
-    the associated dependency's hint, implicitly demanding that it be loaded before it is required.
-
-    This is always true for the usual use case, the plugin framework. For standalone tools
-    this is never true and causes load errors. An alternative, <ExcludeFromSingleFile> is
-    available, but suffers from two crippling flaws:
-    - it has no effect on <PackageReference>s
-    - it does not exclude transitive runtime and native dependencies of a <ProjectReference>
-
-    Until it does, we specify it to get a valid `.deps.json`, then purge shared dep DLLs in this target to simulate its effect.
-    -->
-    <Target Name="ExplicitRemoveFromFilesToBundle" BeforeTargets="GenerateSingleFileBundle" DependsOnTargets="PrepareForBundle">
-        <Message Text="List of bundle objects before purging: '@(FilesToBundle)'" Importance="High" />
-
-        <!--
-        To my unfathomable irritation, the only way I've been able to perform this is by regex.
-        -->
+    <Target Name="_FhMakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
         <ItemGroup>
-            <FilesToBundle Remove="@(FilesToBundle)" Condition="
-            $([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)',
-            '\A(?:TerraFX\.Interop\.Windows|Hexa\.NET\.(?:DirectXTex|ImGui|ImGui\.Backends)|HexaGen\.(?:Runtime|Runtime\.COM)|ImGuiImpl|cimgui|DirectXTex)\z'))" />
+            <!-- remove the transitive project references and re-add them as non-private project references -->
+            <ProjectReference Remove="@(_TransitiveProjectReferences)" />
+            <ProjectReference Include="@(_TransitiveProjectReferences)" Private="False" />
         </ItemGroup>
-
-        <Message Text="List of bundle objects after purging: '@(FilesToBundle)'" Importance="High" />
     </Target>
+
+    <!-- fkelava 09/06/26 17:36
+    A placeholder target to force publishing to occur after a build.
+    Publishing places build output in its proper place.
+    -->
+    <Target Name="_FhPublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" />
+
 </Project>

--- a/src/sdk/Sdk/Sdk.targets
+++ b/src/sdk/Sdk/Sdk.targets
@@ -8,7 +8,7 @@
     Mods must not include any Fahrenheit core or mod libraries in their build output.
     The SDK ensures this- and so must the user- by structuring <ProjectReference>s as such:
 
-    <ProjectReference Include="...">
+    <ProjectReference Include="PATH_TO_PROJECT_HERE">
         <Private>false</Private>
         <ExcludeAssets>runtime;native</ExcludeAssets>
     </ProjectReference>

--- a/src/sdk/Sdk/Sdk.targets
+++ b/src/sdk/Sdk/Sdk.targets
@@ -31,4 +31,37 @@
     -->
     <Target Name="__FhPublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" />
 
+    <!-- fkelava 11/06/26
+    The manifest uniquely identifies and describes a Fahrenheit mod and specifies some runtime behavioral flags.
+    It used to be written out manually, but now it is generated based on various well-known assembly properties.
+    -->
+    <Target Name="__FhEmitManifest" AfterTargets="Publish" >
+        <PropertyGroup>
+            <!--
+            We unconditionally prefer RepositoryUrl where available.
+            -->
+            <FhManifestHomePage Condition=" '$(RepositoryUrl)' != '' ">$(RepositoryUrl)</FhManifestHomePage>
+
+            <__FhManifestFile>$(PublishDir)/$(AssemblyName).manifest.json</__FhManifestFile>
+            <__FhManifestLines>
+{
+    "Id":"$(AssemblyName)",
+    "Name":"$(AssemblyTitle)",
+    "Desc":"$(Description)",
+    "Authors":"$(Authors)",
+    "Version":"$(InformationalVersion)",
+    "Link":"$(FhManifestHomePage)",
+    "Dependencies":[],
+    "LoadAfter":[],
+    "Flags":"$(FhManifestFlags)"
+}
+            </__FhManifestLines>
+        </PropertyGroup>
+
+        <WriteLinesToFile
+            File="$(__FhManifestFile)"
+            Lines="$(__FhManifestLines)"
+            Overwrite="true" />
+    </Target>
+
 </Project>

--- a/src/sdk/Sdk/Sdk.targets
+++ b/src/sdk/Sdk/Sdk.targets
@@ -1,4 +1,5 @@
 <Project>
+
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
     <!-- fkelava 30/09/25 23:05
@@ -16,7 +17,7 @@
     respect the chain of ExcludeAssets tags and emit Fahrenheit libraries alongside
     the mod, which is invalid and will cause issues. This target solves that problem.
     -->
-    <Target Name="_FhMakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
+    <Target Name="__FhMakeTransitiveProjectRefsNonPrivate" AfterTargets="IncludeTransitiveProjectReferences">
         <ItemGroup>
             <!-- remove the transitive project references and re-add them as non-private project references -->
             <ProjectReference Remove="@(_TransitiveProjectReferences)" />
@@ -28,6 +29,6 @@
     A placeholder target to force publishing to occur after a build.
     Publishing places build output in its proper place.
     -->
-    <Target Name="_FhPublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" />
+    <Target Name="__FhPublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" />
 
 </Project>


### PR DESCRIPTION
Fixes #163 by generating ``.snupkg`` that will be uploaded alongside Fahrenheit NuGet packages.

Source Link now gives 'Valid with Symbol Server', presumably permitting debuggers to retrieve Fahrenheit symbols automatically.

SDK now autogenerates the manifest on behalf of the user based on well-known MSBuild properties.

See also https://github.com/fahrenheit-crew/fh-mods-template/pull/3 for an example of the practical effects.