### PR TITLE
Disable automatic code analysis for the main project

### DIFF
--- a/src/core/Fahrenheit.csproj
+++ b/src/core/Fahrenheit.csproj
@@ -47,6 +47,12 @@
         <Product>Fahrenheit Mod Framework</Product>
     </PropertyGroup>
 
+    <!-- CODE ANALYSIS CONTROLS -->
+    <PropertyGroup>
+        <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+        <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    </PropertyGroup>
+
     <!-- SHARED FILE LINKS -->
     <ItemGroup>
         <None Include="$(SolutionDir)\.editorconfig" Link=".editorconfig" />


### PR DESCRIPTION
Closes #164.

This PR is drafted as one of the potential ways we can address the fact that in both Rider and VS, real-time code analysis is both time- and memory-consuming with a solution of the sheer size of Fahrenheit. Furthermore, VS has recently had some issues of its own with excessive memory consumption that is a significant drain on performance. 

We should therefore _consider_ whether disabling automatic code analysis (and thus forcing devs interacting with this repo to run it manually at their leisure) provides a compelling benefit. If not, then the PR should be rejected.