### PR TITLE
Add limited first-chance and unhandled exception handling

### DIFF
--- a/src/core/bootloader.cs
+++ b/src/core/bootloader.cs
@@ -17,6 +17,16 @@ internal static class FhEnvironment {
     internal static readonly string       StateHash;
 
     static FhEnvironment() {
+        /* [fkelava 10/06/26 18:53]
+         * https://learn.microsoft.com/en-us/dotnet/api/system.appdomain?view=net-10.0#remarks
+         * > On .NET Core and .NET 5+ {...} These versions have exactly one AppDomain.
+         *
+         * This should suffice to catch any normal (non-AV) managed exception. In theory.
+         */
+
+        AppDomain.CurrentDomain.FirstChanceException += FhExceptionHandler.eh_first_chance;
+        AppDomain.CurrentDomain.UnhandledException   += FhExceptionHandler.eh_unhandled;
+
         Finder    = new();
         BaseAddr  = NativeLibrary.GetMainProgramHandle();
         LoadOrder = _init_load_order();
@@ -137,6 +147,7 @@ internal sealed class FhLoadContext(string context_name, string fh_dll_path) : A
 ///     and instantiates any <see cref="FhModule"/> with a valid <see cref="FhLoadAttribute"/> on them.
 /// </summary>
 internal sealed class FhLoader {
+
     private readonly Dictionary<string, FhLoadContext> _load_contexts = [];
 
     internal FhLoader() {

--- a/src/core/eh.cs
+++ b/src/core/eh.cs
@@ -1,0 +1,49 @@
+﻿// SPDX-License-Identifier: MIT
+
+namespace Fahrenheit;
+
+/// <summary>
+///     Provides exception handling methods; in our case, 'handling' means 'logging'.
+/// </summary>
+internal static class FhExceptionHandler {
+    private static int _lock_eh_first_chance = 0;
+
+    /* [fkelava 11/06/26 23:02]
+     * Normally only an unhandled exception logger would be provided, if not for the mildly annoying fact
+     * it sporadically won't fire. For this reason we also log first-chance exceptions, even though that
+     * can result in double (or even triple) logging of certain exceptions.
+     *
+     * Note also that severe faults such as AVs are not interceptible in modern .NET.
+     * These only function for run-of-the-mill managed exceptions.
+     */
+
+    internal static void eh_first_chance(object? sender, FirstChanceExceptionEventArgs e) {
+        /* [fkelava 11/06/26 11:28]
+         * See https://learn.microsoft.com/en-us/dotnet/api/system.appdomain.firstchanceexception?view=net-10.0#remarks.
+         * > You must handle all exceptions that occur in the event handler
+         * > for the FirstChanceException event. Otherwise, FirstChanceException is raised recursively.
+         */
+        if (Interlocked.CompareExchange(ref _lock_eh_first_chance, 1, 0) == 1) return;
+
+        try {
+            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
+            FhInternal.Log.Log(FhLogLevel.Fatal, $"First-chance exception at: {TimeProvider.System.GetUtcNow():u}");
+            FhInternal.Log.Log(FhLogLevel.Fatal, e.Exception.ToString());
+            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
+        }
+        catch   { }
+        finally { Interlocked.CompareExchange(ref _lock_eh_first_chance, 0, 1); }
+    }
+
+    internal static void eh_unhandled(object? sender, UnhandledExceptionEventArgs e) {
+        try {
+            Exception ex = (Exception) e.ExceptionObject;
+
+            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
+            FhInternal.Log.Log(FhLogLevel.Fatal, $"Unhandled exception at: {TimeProvider.System.GetUtcNow():u}");
+            FhInternal.Log.Log(FhLogLevel.Fatal, ex.ToString());
+            FhInternal.Log.Log(FhLogLevel.Fatal, "=============================");
+        }
+        catch { }
+    }
+}

--- a/src/core/log.cs
+++ b/src/core/log.cs
@@ -32,60 +32,65 @@ public class FhLogger {
         _file    = new TextWriterTraceListener(File.Open(log_path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite));
     }
 
-    internal void Log(FhLogLevel level,
-                      string     msg) {
-        if (level < MinLevel) return;
-
-        _console.WriteLine(msg);
-        _file   .WriteLine(msg);
+    /// <summary>
+    ///     Logs a given <paramref name="message"/> unconditionally,
+    ///     without timestamp or caller information.
+    /// </summary>
+    internal void Log(string message) {
+        _console.WriteLine(message);
+        _file   .WriteLine(message);
         _file   .Flush();
     }
 
+    /// <summary>
+    ///     Logs a given <paramref name="message"/> at a given <paramref name="level"/>,
+    ///     prepending a timestamp and caller information.
+    /// </summary>
     public void Log(                   FhLogLevel level,
-                                       string     msg,
-                    [CallerMemberName] string     mname = "",
-                    [CallerFilePath]   string     fpath = "",
-                    [CallerLineNumber] int        lnb   = 0) {
+                                       string     message,
+                    [CallerMemberName] string     member = "",
+                    [CallerFilePath]   string     file   = "",
+                    [CallerLineNumber] int        line   = 0) {
         if (level < MinLevel) return;
-        string lstr = $"{TimeProvider.System.GetUtcNow():u} | [{level}] {Path.GetFileName(fpath)}:{lnb} ({mname}): {msg}";
+        string lstr = $"{TimeProvider.System.GetUtcNow():u} | [{level}] {Path.GetFileName(file)}:{line} ({member}): {message}";
 
         _console.WriteLine(lstr);
         _file   .WriteLine(lstr);
         _file   .Flush();
     }
 
-    public void Debug(                   string msg,
-                      [CallerMemberName] string mname = "",
-                      [CallerFilePath]   string fpath = "",
-                      [CallerLineNumber] int    lnb   = 0) {
-        Log(FhLogLevel.Debug, msg, mname, fpath, lnb);
+    public void Debug(                   string message,
+                      [CallerMemberName] string member = "",
+                      [CallerFilePath]   string file   = "",
+                      [CallerLineNumber] int    line   = 0) {
+        Log(FhLogLevel.Debug, message, member, file, line);
     }
 
-    public void Info(                   string msg,
-                     [CallerMemberName] string mname = "",
-                     [CallerFilePath]   string fpath = "",
-                     [CallerLineNumber] int    lnb   = 0) {
-        Log(FhLogLevel.Info, msg, mname, fpath, lnb);
+    public void Info(                   string message,
+                     [CallerMemberName] string member = "",
+                     [CallerFilePath]   string file   = "",
+                     [CallerLineNumber] int    line   = 0) {
+        Log(FhLogLevel.Info, message, member, file, line);
     }
 
-    public void Warning(                   string msg,
-                        [CallerMemberName] string mname = "",
-                        [CallerFilePath]   string fpath = "",
-                        [CallerLineNumber] int    lnb   = 0) {
-        Log(FhLogLevel.Warning, msg, mname, fpath, lnb);
+    public void Warning(                   string message,
+                        [CallerMemberName] string member = "",
+                        [CallerFilePath]   string file   = "",
+                        [CallerLineNumber] int    line   = 0) {
+        Log(FhLogLevel.Warning, message, member, file, line);
     }
 
-    public void Error(                   string msg,
-                      [CallerMemberName] string mname = "",
-                      [CallerFilePath]   string fpath = "",
-                      [CallerLineNumber] int    lnb   = 0) {
-        Log(FhLogLevel.Error, msg, mname, fpath, lnb);
+    public void Error(                   string message,
+                      [CallerMemberName] string member = "",
+                      [CallerFilePath]   string file   = "",
+                      [CallerLineNumber] int    line   = 0) {
+        Log(FhLogLevel.Error, message, member, file, line);
     }
 
-    public void Fatal(                   string msg,
-                      [CallerMemberName] string mname = "",
-                      [CallerFilePath]   string fpath = "",
-                      [CallerLineNumber] int    lnb   = 0) {
-        Log(FhLogLevel.Fatal, msg, mname, fpath, lnb);
+    public void Fatal(                   string message,
+                      [CallerMemberName] string member = "",
+                      [CallerFilePath]   string file   = "",
+                      [CallerLineNumber] int    line   = 0) {
+        Log(FhLogLevel.Fatal, message, member, file, line);
     }
 }

--- a/src/core/log.cs
+++ b/src/core/log.cs
@@ -32,13 +32,22 @@ public class FhLogger {
         _file    = new TextWriterTraceListener(File.Open(log_path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite));
     }
 
+    internal void Log(FhLogLevel level,
+                      string     msg) {
+        if (level < MinLevel) return;
+
+        _console.WriteLine(msg);
+        _file   .WriteLine(msg);
+        _file   .Flush();
+    }
+
     public void Log(                   FhLogLevel level,
                                        string     msg,
                     [CallerMemberName] string     mname = "",
                     [CallerFilePath]   string     fpath = "",
                     [CallerLineNumber] int        lnb   = 0) {
         if (level < MinLevel) return;
-        string lstr = $"{DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)} | [{level}] {Path.GetFileName(fpath)}:{lnb.ToString()} ({mname}): {msg}";
+        string lstr = $"{TimeProvider.System.GetUtcNow():u} | [{level}] {Path.GetFileName(fpath)}:{lnb} ({mname}): {msg}";
 
         _console.WriteLine(lstr);
         _file   .WriteLine(lstr);

--- a/src/core/usings.cs
+++ b/src/core/usings.cs
@@ -1,22 +1,23 @@
-﻿global using System;                          // primitives
-global using System.Buffers;                  // OperationStatus for Rune decoding, et al.
-global using System.Buffers.Binary;           // BinaryPrimitives, et al.
-global using System.Collections.Generic;      // List<T>, Dictionary<T,U> and others
-global using System.Diagnostics;              // [Conditional] et al.
-global using System.Diagnostics.CodeAnalysis; // [NotNullWhen()] and other nullability static analysis attributes
-global using System.Globalization;            // CultureInfo.InvariantCulture et al.
-global using System.IO;                       // Path, File, and similar
-global using System.Numerics;                 // generic math - INumber<T>, IBinaryInteger<T>
-global using System.Reflection;               // Assembly
-global using System.Runtime.CompilerServices; // [InlineArray]
-global using System.Runtime.InteropServices;  // [DllImport], [LibraryImport], et al.
-global using System.Runtime.Loader;           // AssemblyLoadContext, AssemblyDependencyResolver
-global using System.Runtime.Versioning;       // [SupportedOSPlatform]
-global using System.Security.Cryptography;    // SHA-256 for state hashing
-global using System.Text;                     // Encoding
-global using System.Text.Json;                // For JSON (de)serialization, we use STJ.
+﻿global using System;                           // primitives
+global using System.Buffers;                   // OperationStatus for Rune decoding, et al.
+global using System.Buffers.Binary;            // BinaryPrimitives, et al.
+global using System.Collections.Generic;       // List<T>, Dictionary<T,U> and others
+global using System.Diagnostics;               // [Conditional] et al.
+global using System.Diagnostics.CodeAnalysis;  // [NotNullWhen()] and other nullability static analysis attributes
+global using System.Globalization;             // CultureInfo.InvariantCulture et al.
+global using System.IO;                        // Path, File, and similar
+global using System.Numerics;                  // generic math - INumber<T>, IBinaryInteger<T>
+global using System.Reflection;                // Assembly
+global using System.Runtime.CompilerServices;  // [InlineArray]
+global using System.Runtime.ExceptionServices; // First-chance EH
+global using System.Runtime.InteropServices;   // [DllImport], [LibraryImport], et al.
+global using System.Runtime.Loader;            // AssemblyLoadContext, AssemblyDependencyResolver
+global using System.Runtime.Versioning;        // [SupportedOSPlatform]
+global using System.Security.Cryptography;     // SHA-256 for state hashing
+global using System.Text;                      // Encoding
+global using System.Text.Json;                 // For JSON (de)serialization, we use STJ.
 global using System.Text.Json.Serialization;
-global using System.Threading;                // Lock
+global using System.Threading;                 // Lock
 
 global using Fahrenheit.Events;
 

--- a/src/stage0/src/main.cpp
+++ b/src/stage0/src/main.cpp
@@ -91,6 +91,8 @@ int wmain(int argc, wchar_t* argv[ ]) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 
+    std::wcout << std::endl;
+
     if (exitCode != 0) {
         std::wcout << "Process exited with code " << exitCode << std::endl;
         std::wcout << "If reporting an issue, please include any core dump (*.dmp) you see in the game directory.\n";


### PR DESCRIPTION
Fixes #162.

This only serves to log normal managed exceptions. That is, "hard faults" are not interceptible.
See https://learn.microsoft.com/en-us/dotnet/api/system.appdomain.firstchanceexception?view=net-10.0#remarks:
> This event is not raised for exceptions that indicate corruption of process state, such as access violations {...}

In .NET Framework an attribute existed to override this (https://learn.microsoft.com/en-us/dotnet/api/system.runtime.exceptionservices.handleprocesscorruptedstateexceptionsattribute?view=net-10.0), but .NET Core has no such provision:
> Even though this attribute exists in .NET Core, since the recovery from corrupted process state exceptions is not supported, this attribute is ignored. The CLR doesn't deliver corrupted process state exceptions to the managed code.