### PR TITLE
Add native exception handler, write customized core dumps

### DIFF
--- a/src/core/bootloader.cs
+++ b/src/core/bootloader.cs
@@ -21,11 +21,13 @@ internal static class FhEnvironment {
          * https://learn.microsoft.com/en-us/dotnet/api/system.appdomain?view=net-10.0#remarks
          * > On .NET Core and .NET 5+ {...} These versions have exactly one AppDomain.
          *
-         * This should suffice to catch any normal (non-AV) managed exception. In theory.
+         * In other words, AppDomain.CurrentDomain is the _only_ domain in existence.
+         * See the comments on FhExceptionHandler for the peculiar nature of events here.
          */
+        ExceptionHandling.SetUnhandledExceptionHandler(FhExceptionHandler.eh_unhandled);
+        // ExceptionHandling.SetFatalErrorHandler(FhExceptionHandler.eh_fatal); // Uncomment when added in .NET 11/12.
 
         AppDomain.CurrentDomain.FirstChanceException += FhExceptionHandler.eh_first_chance;
-        AppDomain.CurrentDomain.UnhandledException   += FhExceptionHandler.eh_unhandled;
 
         Finder    = new();
         BaseAddr  = NativeLibrary.GetMainProgramHandle();

--- a/src/core/eh.cs
+++ b/src/core/eh.cs
@@ -2,48 +2,86 @@
 
 namespace Fahrenheit;
 
+/* [fkelava 11/06/26 23:02]
+ * Before an exception tears the process down, we want to log it and
+ * dump core to disk, since the game won't always do so. It turns out this is difficult.
+ *
+ * .NET has two 'unhandled exception handlers' - AppDomain.UnhandledException
+ * and ExceptionHandling.SetUnhandledExceptionHandler (.NET 10+). They have different semantics.
+ *
+ * Furthermore, some of these are only raised for some classes of exceptions.
+ * Here's the table I've been able to piece together:
+ *                                           AD.FC | AD.UE | SUEH
+ * ---
+ * Exception on user-spawned thread             X      X      X
+ * Exception on application main thread         X      X      -
+ * Exception on application non-main thread     X      -      -
+ * Task exception (unobserved)                  X      -      -
+ * ---
+ * We therefore install a first-chance filter and the 'newer' ExceptionHandling API.
+ *
+ * The 'dump core to disk' part can't be implemented in C# at all because we need
+ * it to be active during Fahrenheit's early initialization as well; it's done in Stage1 instead.
+ *
+ * But- fatal errors (AV/EEE) are not interceptible at all, and will pre-empt
+ * even our native exception handler as the runtime tears the process down immediately.
+ * To work around that, we have to wait for https://github.com/dotnet/runtime/issues/101560.
+ */
+
 /// <summary>
-///     Provides exception handling methods; in our case, 'handling' means 'logging'.
+///     Provides exception handling methods.
 /// </summary>
 internal static class FhExceptionHandler {
-    private static int _lock_eh_first_chance = 0;
 
-    /* [fkelava 11/06/26 23:02]
-     * Normally only an unhandled exception logger would be provided, if not for the mildly annoying fact
-     * it sporadically won't fire. For this reason we also log first-chance exceptions, even though that
-     * can result in double (or even triple) logging of certain exceptions.
+    private static readonly FhLogger _eh_log = new("error.log");
+
+    /* [fkelava 14/06/26 14:23]
+     * The try-catch blocks have a dual purpose.
      *
-     * Note also that severe faults such as AVs are not interceptible in modern .NET.
-     * These only function for run-of-the-mill managed exceptions.
+     * First, https://learn.microsoft.com/en-us/dotnet/api/system.appdomain.firstchanceexception?view=net-10.0#remarks:
+     * > You must handle all exceptions that occur in the event handler
+     * > for the FirstChanceException event. Otherwise, FirstChanceException is raised recursively.
+     *
+     * Second, there is one edge case in which these will throw; a failure in initializing `FhEnvironment.Finder`,
+     * because `FhLogger` relies on it. But initializing it is the first act Fahrenheit does _after_ installing EH,
+     * so the window in which that can happen is vanishingly brief (and Finder itself will only fail if we can't
+     * R/W to our own directory...)
      */
 
+    /// <summary>
+    ///     Runs in response to <see cref="AppDomain.FirstChanceException"/>.
+    /// </summary>
     internal static void eh_first_chance(object? sender, FirstChanceExceptionEventArgs e) {
         /* [fkelava 11/06/26 11:28]
          * See https://learn.microsoft.com/en-us/dotnet/api/system.appdomain.firstchanceexception?view=net-10.0#remarks.
          * > You must handle all exceptions that occur in the event handler
          * > for the FirstChanceException event. Otherwise, FirstChanceException is raised recursively.
          */
-        if (Interlocked.CompareExchange(ref _lock_eh_first_chance, 1, 0) == 1) return;
-
         try {
-            FhInternal.Log.Log("================================");
-            FhInternal.Log.Log($"First-chance exception at: {TimeProvider.System.GetUtcNow():u}");
-            FhInternal.Log.Log(e.Exception.ToString());
-            FhInternal.Log.Log("================================");
-        }
-        catch   { }
-        finally { Interlocked.CompareExchange(ref _lock_eh_first_chance, 0, 1); }
-    }
-
-    internal static void eh_unhandled(object? sender, UnhandledExceptionEventArgs e) {
-        try {
-            Exception ex = (Exception) e.ExceptionObject;
-
-            FhInternal.Log.Log("================================");
-            FhInternal.Log.Log($"Unhandled exception at: {TimeProvider.System.GetUtcNow():u}");
-            FhInternal.Log.Log(ex.ToString());
-            FhInternal.Log.Log("=============================");
+            _eh_log.LogDirect($"First-chance exception at: {TimeProvider.System.GetUtcNow():u}");
+            _eh_log.LogDirect(e.Exception.ToString());
+            _eh_log.LogDirect("================================");
         }
         catch { }
+    }
+
+    /// <summary>
+    ///     Installed through <see cref="ExceptionHandling.SetUnhandledExceptionHandler(Func{Exception, bool})"/>.
+    /// </summary>
+    internal static bool eh_unhandled(Exception ex) {
+        try {
+            _eh_log.LogDirect($"Unhandled exception at: {TimeProvider.System.GetUtcNow():u}");
+            _eh_log.LogDirect(ex.ToString());
+            _eh_log.LogDirect("================================");
+        }
+        catch { }
+
+        /* [fkelava 13/06/26 12:38]
+         * See https://source.dot.net/#System.Private.CoreLib/System/Threading/Thread.NativeAot.cs,445,
+         * https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when#when-in-a-catch-clause
+         *
+         * We are very explicitly not _handling_ it. We just want to know it happened.
+         */
+        return false;
     }
 }

--- a/src/core/eh.cs
+++ b/src/core/eh.cs
@@ -26,10 +26,10 @@ internal static class FhExceptionHandler {
         if (Interlocked.CompareExchange(ref _lock_eh_first_chance, 1, 0) == 1) return;
 
         try {
-            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
-            FhInternal.Log.Log(FhLogLevel.Fatal, $"First-chance exception at: {TimeProvider.System.GetUtcNow():u}");
-            FhInternal.Log.Log(FhLogLevel.Fatal, e.Exception.ToString());
-            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
+            FhInternal.Log.Log("================================");
+            FhInternal.Log.Log($"First-chance exception at: {TimeProvider.System.GetUtcNow():u}");
+            FhInternal.Log.Log(e.Exception.ToString());
+            FhInternal.Log.Log("================================");
         }
         catch   { }
         finally { Interlocked.CompareExchange(ref _lock_eh_first_chance, 0, 1); }
@@ -39,10 +39,10 @@ internal static class FhExceptionHandler {
         try {
             Exception ex = (Exception) e.ExceptionObject;
 
-            FhInternal.Log.Log(FhLogLevel.Fatal, "================================");
-            FhInternal.Log.Log(FhLogLevel.Fatal, $"Unhandled exception at: {TimeProvider.System.GetUtcNow():u}");
-            FhInternal.Log.Log(FhLogLevel.Fatal, ex.ToString());
-            FhInternal.Log.Log(FhLogLevel.Fatal, "=============================");
+            FhInternal.Log.Log("================================");
+            FhInternal.Log.Log($"Unhandled exception at: {TimeProvider.System.GetUtcNow():u}");
+            FhInternal.Log.Log(ex.ToString());
+            FhInternal.Log.Log("=============================");
         }
         catch { }
     }

--- a/src/core/log.cs
+++ b/src/core/log.cs
@@ -36,7 +36,7 @@ public class FhLogger {
     ///     Logs a given <paramref name="message"/> unconditionally,
     ///     without timestamp or caller information.
     /// </summary>
-    internal void Log(string message) {
+    internal void LogDirect(string message) {
         _console.WriteLine(message);
         _file   .WriteLine(message);
         _file   .Flush();

--- a/src/stage0/Fahrenheit.Loader.Stage0.vcxproj
+++ b/src/stage0/Fahrenheit.Loader.Stage0.vcxproj
@@ -93,7 +93,7 @@
     <IntDir>$(_FhBaseIntermediateOutputPath)</IntDir>
     <OutDir>$(_FhOutDirBin)</OutDir>
     <TargetName>fhstage0</TargetName>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />

--- a/src/stage0/src/main.cpp
+++ b/src/stage0/src/main.cpp
@@ -94,7 +94,7 @@ int wmain(int argc, wchar_t* argv[ ]) {
     std::wcout << std::endl;
 
     if (exitCode != 0) {
-        std::wcout << "Process exited with code " << exitCode << std::endl;
+        std::wcout << "Process exited with code " << std::hex << exitCode << std::endl;
         std::wcout << "If reporting an issue, please include any core dump (*.dmp) you see in the game directory.\n";
     }
     else {

--- a/src/stage1/Fahrenheit.Loader.Stage1.vcxproj
+++ b/src/stage1/Fahrenheit.Loader.Stage1.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/src/stage1/inc/fhstage1.h
+++ b/src/stage1/inc/fhstage1.h
@@ -5,8 +5,9 @@
  */
 
 #pragma once
+#pragma comment(lib, "dbghelp.lib")
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 
 #include <stdio.h>
 #include <stdint.h>
@@ -17,24 +18,13 @@
 #include <fstream>
 #include <direct.h>
 
-#ifdef _WIN32
 #include <windows.h>
 #include <winternl.h>
+#include <DbgHelp.h>
 
 #define STR(s) L ## s
 #define CH(c)  L ## c
 #define DIR_SEPARATOR L'\\'
-
-#else
-#include <dlfcn.h>
-#include <limits.h>
-
-#define STR(s) s
-#define CH(c) c
-#define DIR_SEPARATOR '/'
-#define MAX_PATH PATH_MAX
-
-#endif
 
  // .NET hosting headers
 #include <nethost.h>

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -134,7 +134,7 @@ stage1_eh_filter_dump(
 
         case IncludeThreadCallback: {
             // Exclude the thread which writes the minidump.
-            return CallbackInput->Thread.ThreadId != g_eh_thread_handler_id;
+            return CallbackInput->IncludeThread.ThreadId != g_eh_thread_handler_id;
         } break;
     }
 

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -2,92 +2,224 @@
  * Uses code from the .NET NativeHost sample, used under the MIT license.
  *
  * See THIRD-PARTY-NOTICES.
+ *
+ * For the HostFXR bits, see https://github.com/dotnet/samples/blob/main/core/hosting/src/NativeHost/nativehost.cpp.
+ * For the exception handling, see:
+ * - http://code.aaronballman.com/minidumper/MiniDump.cpp
+ * - https://github.com/folgerwang/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp
  */
 
 #include "fhstage1.h"
 
-typedef void (CORECLR_DELEGATE_CALLTYPE* fh_ldr_managed_init)();
+// Function pointer to managed delegate with our own signature
+typedef void (CORECLR_DELEGATE_CALLTYPE* fh_init)();
 
 using string_t = std::basic_string<char_t>;
-using main_t   = int(*)(void);
+using main_fn  = int(*)(void);
+using eh_fn    = LONG(*)(EXCEPTION_POINTERS*);
 
-main_t pMainOriginal = nullptr; // Original program entrypoint.
-main_t pMainTarget   = nullptr; // Detour of program entrypoint.
+// Globals to hold original and detour addresses of program entrypoint and SEH filter
+main_fn g_fnptr_main_original = nullptr;
+main_fn g_fnptr_main_target   = nullptr;
+eh_fn   g_fnptr_eh_original   = nullptr;
+eh_fn   g_fnptr_eh_target     = nullptr;
 
-namespace {
-    // Globals to hold hostfxr exports
-    hostfxr_initialize_for_runtime_config_fn init_fptr;
-    hostfxr_get_runtime_delegate_fn          get_delegate_fptr;
-    hostfxr_close_fn                         close_fptr;
+// Globals for EH override
+DWORD               g_eh_thread_faulting_id;
+DWORD               g_eh_thread_handler_id;
+HANDLE              g_eh_thread_handler;
+EXCEPTION_POINTERS* g_eh_exception_ptr;
 
-    // Forward declarations
-    bool load_hostfxr();
+// Globals to hold hostfxr exports
+hostfxr_initialize_for_runtime_config_fn g_fnptr_hostfxr_init;
+hostfxr_get_runtime_delegate_fn          g_fnptr_hostfxr_get_delegate;
+hostfxr_close_fn                         g_fnptr_hostfxr_close;
+
+// Using the nethost library, discover the location of hostfxr and get exports
+static bool load_hostfxr() {
+    // Pre-allocate a large buffer for the path to hostfxr
+    char_t buffer[MAX_PATH];
+    size_t buffer_size = sizeof(buffer) / sizeof(char_t);
+
+    int rc = get_hostfxr_path(buffer, &buffer_size, nullptr);
+    if (rc != 0) {
+        std::wcerr << "get_hostfxr_path() failed, error code: " << rc << std::endl;
+        return false;
+    }
+
+    // Load hostfxr and get desired exports
+    HMODULE lib = ::LoadLibraryW(buffer);
+
+    if (lib == nullptr)
+        return FALSE;
+
+    g_fnptr_hostfxr_init         = (hostfxr_initialize_for_runtime_config_fn)::GetProcAddress(lib, "hostfxr_initialize_for_runtime_config");
+    g_fnptr_hostfxr_get_delegate = (hostfxr_get_runtime_delegate_fn)         ::GetProcAddress(lib, "hostfxr_get_runtime_delegate");
+    g_fnptr_hostfxr_close        = (hostfxr_close_fn)                        ::GetProcAddress(lib, "hostfxr_close");
+
+    return (g_fnptr_hostfxr_init && g_fnptr_hostfxr_get_delegate && g_fnptr_hostfxr_close);
 }
 
-/********************************************************************************************
- * Function used to load and activate .NET Core
- ********************************************************************************************/
+/* [fkelava 11/06/26 16:27]
+ * An exception handler which behaves the same as the game's,
+ * except that it _unconditionally_ emits a customized core dump.
+ *
+ * We catch managed exceptions in C#, and this filter catches native or fatal exceptions for logging.
+ *
+ * See:
+ * - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+ * - https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-unhandledexceptionfilter
+ * - FFX.exe+226A90
+ * - https://www.debuginfo.com/examples/src/effminidumps/MiniDump.cpp
+ */
 
-namespace {
-    // Forward declarations
-    void *load_library(const char_t *);
-    void *get_export(void *, const char *);
+// Filters the core dump to exclude objects which we do not want to record.
+static BOOL CALLBACK stage1_eh_filter_dump(
+          PVOID                     CallbackParam,
+    const PMINIDUMP_CALLBACK_INPUT  CallbackInput,
+          PMINIDUMP_CALLBACK_OUTPUT CallbackOutput) {
+    if (!CallbackInput || !CallbackOutput) return FALSE;
 
-#ifdef _WIN32
-    void *load_library(const char_t *path)
-    {
-        HMODULE h = ::LoadLibraryW(path);
-        assert(h != nullptr);
-        return (void*)h;
-    }
-    void *get_export(void *h, const char *name)
-    {
-        void *f = ::GetProcAddress((HMODULE)h, name);
-        assert(f != nullptr);
-        return f;
-    }
-#else
-    void *load_library(const char_t *path)
-    {
-        void *h = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
-        assert(h != nullptr);
-        return h;
-    }
-    void *get_export(void *h, const char *name)
-    {
-        void *f = dlsym(h, name);
-        assert(f != nullptr);
-        return f;
-    }
-#endif
+    switch (CallbackInput->CallbackType) {
+        case CancelCallback:
+            return FALSE;
 
-    // Using the nethost library, discover the location of hostfxr and get exports
-    bool load_hostfxr() {
-        // Pre-allocate a large buffer for the path to hostfxr
-        char_t buffer[MAX_PATH];
-        size_t buffer_size = sizeof(buffer) / sizeof(char_t);
+        case IncludeThreadCallback: {
+            // Exclude the thread which writes the minidump.
+            return CallbackInput->IncludeThread.ThreadId != g_eh_thread_handler_id;
+        } break;
+    }
 
-        int rc = get_hostfxr_path(buffer, &buffer_size, nullptr);
-        if (rc != 0) {
-            std::wcerr << "get_hostfxr_path() failed, error code: " << rc << std::endl;
-            return false;
+    return TRUE;
+}
+
+// Writes a customized core dump.
+static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
+    HANDLE hFile = CreateFileW(
+        L"fahrenheit.dmp",
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nullptr,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+
+    if (hFile == NULL || hFile == INVALID_HANDLE_VALUE) {
+        std::wcerr << "Failed to open a file to write the core dump to." << std::endl;
+        return 1;
+    }
+
+    HANDLE        hProcess  = GetCurrentProcess();
+    DWORD         ProcessId = GetProcessId(hProcess);
+    MINIDUMP_TYPE DumpType  = (MINIDUMP_TYPE)(
+                              MiniDumpWithThreadInfo
+                            | MiniDumpWithFullMemoryInfo
+                            | MiniDumpWithProcessThreadData
+                            | MiniDumpWithHandleData
+                            | MiniDumpWithDataSegs);
+
+    /* [fkelava 11/06/26 21:24]
+     * For ClientPointers:
+     * https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception_information#members
+     * > If you are accessing local memory (in the calling process) you should not set this member to TRUE.
+     */
+    MINIDUMP_EXCEPTION_INFORMATION mdei = { 0 };
+    mdei.ThreadId          = g_eh_thread_faulting_id;
+    mdei.ExceptionPointers = g_eh_exception_ptr;
+    mdei.ClientPointers    = FALSE;
+
+    MINIDUMP_CALLBACK_INFORMATION mci = { 0 };
+    mci.CallbackRoutine = (MINIDUMP_CALLBACK_ROUTINE)stage1_eh_filter_dump;
+    mci.CallbackParam   = nullptr;
+
+    PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam = g_eh_exception_ptr != 0 ? &mdei : nullptr;
+    PMINIDUMP_CALLBACK_INFORMATION  CallbackParam  = &mci;
+
+    BOOL rv = MiniDumpWriteDump(
+        hProcess,
+        ProcessId,
+        hFile,
+        DumpType,
+        ExceptionParam,
+        nullptr,
+        CallbackParam);
+
+    if (!rv) {
+        std::wcerr << "Failed to capture a core dump." << std::endl;
+        return 1;
+    }
+
+    CloseHandle(hFile);
+    return 0;
+}
+
+// The Stage1 exception handler.
+static LONG WINAPI stage1_eh(EXCEPTION_POINTERS* ExceptionInfo) {
+    g_eh_exception_ptr      = ExceptionInfo;
+    g_eh_thread_faulting_id = GetCurrentThreadId();
+
+    ::ResumeThread(g_eh_thread_handler);
+    ::WaitForSingleObject(g_eh_thread_handler, INFINITE);
+    ::CloseHandle(g_eh_thread_handler);
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+// If necessary, replaces the game's EH filter with a Stage1 custom one.
+static BOOL stage1_eh_install(LPBYTE pMainModule) {
+    char_t exe_full_name_buf[MAX_PATH];
+    auto size = ::GetModuleFileNameW(NULL, exe_full_name_buf, sizeof(exe_full_name_buf) / sizeof(char_t));
+
+    string_t exe_full_name       = exe_full_name_buf;
+    size_t   exe_name_dirsep_pos = exe_full_name.find_last_of(DIR_SEPARATOR) + 1;
+
+    if (exe_name_dirsep_pos == string_t::npos) {
+        std::wcerr << "The path to the target binary is invalid." << std::endl;
+        return FALSE;
+    }
+
+    string_t exe_name = exe_full_name.substr(exe_name_dirsep_pos, exe_full_name.length());
+
+    // This can be generalized for other games in the future.
+    bool is_ffx            = exe_name.compare(L"FFX.exe")   == 0;
+    bool is_ffx2           = exe_name.compare(L"FFX-2.exe") == 0;
+    bool should_install_eh = is_ffx || is_ffx2;
+
+    if (should_install_eh) {
+        std::wcout << "Installing EH hook for " << exe_name << std::endl;
+
+        auto eh_offset = is_ffx ? 0x226A90 : 0x6B6340;
+        g_fnptr_eh_target = reinterpret_cast<eh_fn>(pMainModule + eh_offset);
+
+        if (MH_CreateHook(g_fnptr_eh_target, &stage1_eh, reinterpret_cast<void**>(&g_fnptr_eh_original)) != MH_OK
+        ||  MH_EnableHook(g_fnptr_eh_target)                                                             != MH_OK) {
+            std::wcerr << "Failed to insert EH hook for " << exe_name << std::endl;
+            return FALSE;
         }
 
-        // Load hostfxr and get desired exports
-        void* lib         = load_library(buffer);
-        init_fptr         = (hostfxr_initialize_for_runtime_config_fn)get_export(lib, "hostfxr_initialize_for_runtime_config");
-        get_delegate_fptr = (hostfxr_get_runtime_delegate_fn)         get_export(lib, "hostfxr_get_runtime_delegate");
-        close_fptr        = (hostfxr_close_fn)                        get_export(lib, "hostfxr_close");
+        g_eh_thread_handler = ::CreateThread(
+            nullptr,
+            0,
+            stage1_eh_create_dump,
+            nullptr,
+            CREATE_SUSPENDED,
+            &g_eh_thread_handler_id);
 
-        return (init_fptr && get_delegate_fptr && close_fptr);
+        if (g_eh_thread_handler == nullptr || g_eh_thread_handler == INVALID_HANDLE_VALUE) {
+            std::wcerr << "Failed to create EH thread for " << exe_name << std::endl;
+            return FALSE;
+        }
+
+        ::SetThreadDescription(g_eh_thread_handler, L"Fahrenheit EH");
     }
+
+    return TRUE;
 }
 
-static int DetourMain(void) {
-    //
+// Runs before the program's own entrypoint, setting up Fahrenheit.
+static int stage1_main(void) {
     // STEP 1:
     // Attach to the Stage0 console and forward stdout/stderr to it.
-    //
     if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
         std::wcerr << "Failed to attach to the Stage0 console." << std::endl;
         exit(GetLastError());
@@ -102,17 +234,26 @@ static int DetourMain(void) {
         exit(EXIT_FAILURE);
     }
 
-    //
     // STEP 2:
+    // If supported, install an EH override which allows us to capture
+    // a customized core dump for easier debugging.
+    HMODULE hMainModule = GetModuleHandleW(nullptr);
+    LPBYTE  pMainModule = reinterpret_cast<LPBYTE>(hMainModule);
+
+    if (!stage1_eh_install(pMainModule)) {
+        std::wcerr << "Failed to insert EH hook." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // STEP 3:
     // Determine the current working directory and the location
     // of the executable being launched, to which we will swap
     // the working directory later.
-    //
     char_t host_path_buf[MAX_PATH]; // where is the game?
     char_t cwd_path_buf [MAX_PATH]; // where are _we_?
 
-    auto size     = ::GetModuleFileName  (NULL, host_path_buf, sizeof(host_path_buf) / sizeof(char_t));
-    auto cwd_size = ::GetCurrentDirectory(sizeof(cwd_path_buf) / sizeof(char_t), cwd_path_buf);
+    auto size     = ::GetModuleFileNameW  (NULL, host_path_buf, sizeof(host_path_buf) / sizeof(char_t));
+    auto cwd_size = ::GetCurrentDirectoryW(sizeof(cwd_path_buf) / sizeof(char_t), cwd_path_buf);
 
     if (size == 0) {
         std::wcerr << "GetModuleFileName() failed." << std::endl;
@@ -127,10 +268,8 @@ static int DetourMain(void) {
     string_t host_path = host_path_buf;
     string_t cwd_path  = cwd_path_buf;
 
-    //
-    // STEP 3:
+    // STEP 4:
     // Declare the name, type, and location of the bootstrap method to invoke.
-    //
     const string_t clrhost_config_path = cwd_path + STR("\\fh.runtimeconfig.json");
     const string_t clrhost_lib_path    = cwd_path + STR("\\fh.dll");
     const char_t*  clrhost_type        = STR("Fahrenheit.FhEnvironment, fh");
@@ -147,38 +286,32 @@ static int DetourMain(void) {
 
     host_path = host_path.substr(0, host_dirsep_pos + 1);
 
-    //
-    // STEP 4:
+    // STEP 5:
     // Load HostFxr. This library will locate the .NET runtime for us.
-    //
     if (!load_hostfxr()) {
         std::wcerr << "hostfxr: failed to load" << std::endl;
         std::wcerr << "Fahrenheit failed to load the .NET Runtime. Ensure it is installed as per the setup guide." << std::endl;
         exit(EXIT_FAILURE);
     }
 
-    //
-    // STEP 5:
+    // STEP 6:
     // Initialize and start the .NET runtime.
-    //
     void*          load_assembly_fptr        = nullptr;
     void*          get_function_pointer_fptr = nullptr;
     hostfxr_handle cxt                       = nullptr;
 
-    int rc = init_fptr(clrhost_config_path.c_str(), nullptr, &cxt);
+    int rc = g_fnptr_hostfxr_init(clrhost_config_path.c_str(), nullptr, &cxt);
     if (rc != 0 || cxt == nullptr) {
         std::wcerr << "hostfxr: initialize_for_runtime_config() failed" << std::endl;
         std::wcerr << "This is an uncommon error. Please contact the Fahrenheit developers at https://github.com/fahrenheit-crew/fahrenheit." << std::endl;
 
-        close_fptr(cxt);
+        g_fnptr_hostfxr_close(cxt);
         exit(rc);
     }
 
-    //
-    // STEP 6:
+    // STEP 7:
     // Get function pointers to HostFxr's `load_assembly()` and `get_function_pointer()`.
-    //
-    rc = get_delegate_fptr(
+    rc = g_fnptr_hostfxr_get_delegate(
         cxt,
         hdt_load_assembly,
         &load_assembly_fptr);
@@ -189,7 +322,7 @@ static int DetourMain(void) {
         exit(rc);
     }
 
-    rc = get_delegate_fptr(
+    rc = g_fnptr_hostfxr_get_delegate(
         cxt,
         hdt_get_function_pointer,
         &get_function_pointer_fptr);
@@ -200,16 +333,14 @@ static int DetourMain(void) {
         exit(rc);
     }
 
-    close_fptr(cxt);
+    g_fnptr_hostfxr_close(cxt);
 
     load_assembly_fn        load_assembly        = (load_assembly_fn)       load_assembly_fptr;
     get_function_pointer_fn get_function_pointer = (get_function_pointer_fn)get_function_pointer_fptr;
 
-    //
-    // STEP 7:
+    // STEP 8:
     // Load managed assembly and get function pointer to bootstrap function.
-    //
-    fh_ldr_managed_init fh_init = nullptr;
+    fh_init fnptr_fh_init = nullptr;
 
     rc = load_assembly(
         clrhost_lib_path.c_str(),
@@ -228,58 +359,64 @@ static int DetourMain(void) {
         UNMANAGEDCALLERSONLY_METHOD,
         nullptr,
         nullptr,
-        (void**)&fh_init);
+        (void**)&fnptr_fh_init);
 
-    if (rc != 0 || fh_init == nullptr) {
+    if (rc != 0 || fnptr_fh_init == nullptr) {
         std::wcerr << "hostfxr: get_function_pointer() failed" << std::endl;
         std::wcerr << "Failed to locate the Fahrenheit boot function. You made a change to the bootloader, but forgot to update Stage1." << std::endl;
         exit(rc);
     }
 
-    //
-    // STEP 8:
+    // STEP 9:
     // Boot Fahrenheit by invoking the boot function in `fh.dll`.
-    //
 
     // TRANSITION: NATIVE -> MANAGED
-    fh_init();
+    fnptr_fh_init();
     // TRANSITION: MANAGED -> NATIVE
 
-    //
-    // STEP 9:
+    // STEP 10:
     // Change the working directory to the targeted executable's location,
     // now that we have finished initialization.
-    //
     rc = _wchdir(host_path.c_str());
     if (rc != 0) {
         std::wcerr << "Failed to switch to the game's working directory." << std::endl;
         exit(rc);
     }
 
+    // STEP 11:
+    // Let the game run. Enjoy!
     std::wcout << "Stage 1 Loader complete. The game is now executing." << std::endl;
-    return pMainOriginal();
+    return g_fnptr_main_original();
 }
 
-BOOL APIENTRY DllMain( HMODULE hModule,
-                       DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
+BOOL APIENTRY DllMain( HMODULE hinstDLL,
+                       DWORD   fdwReason,
+                       LPVOID  lpvReserved
                      ) {
-    switch (ul_reason_for_call) {
+    switch (fdwReason) {
         case DLL_PROCESS_ATTACH: {
-            if (!DetourRestoreAfterWith()) exit(GetLastError());
+            // Return the IAT to its original self.
+            if (!DetourRestoreAfterWith())
+                exit(GetLastError());
 
-            auto hMainModule    = reinterpret_cast<HMODULE>          (NtCurrentTeb()->ProcessEnvironmentBlock->Reserved3[1]);
-            auto pImgDosHeaders = reinterpret_cast<PIMAGE_DOS_HEADER>(hMainModule);
-            if (pImgDosHeaders->e_magic  != IMAGE_DOS_SIGNATURE) return TRUE;
+            // Override the program's entrypoint. We need to host the .NET Runtime and boot Fahrenheit first.
+            HMODULE hMainModule = GetModuleHandleW(nullptr);
+            LPBYTE  pMainModule = reinterpret_cast<LPBYTE>(hMainModule);
 
-            auto pImgNTHeaders = reinterpret_cast<PIMAGE_NT_HEADERS> ((reinterpret_cast<LPBYTE>(pImgDosHeaders) + pImgDosHeaders->e_lfanew));
-            if (pImgNTHeaders->Signature != IMAGE_NT_SIGNATURE) return TRUE;
+            PIMAGE_DOS_HEADER pImgDosHeaders = reinterpret_cast<PIMAGE_DOS_HEADER>(hMainModule);
+            if (pImgDosHeaders->e_magic  != IMAGE_DOS_SIGNATURE)
+                return FALSE;
 
-            pMainTarget = reinterpret_cast<main_t>(pImgNTHeaders->OptionalHeader.AddressOfEntryPoint + reinterpret_cast<LPBYTE>(hMainModule));
+            PIMAGE_NT_HEADERS pImgNTHeaders  = reinterpret_cast<PIMAGE_NT_HEADERS>((pMainModule + pImgDosHeaders->e_lfanew));
+            if (pImgNTHeaders->Signature != IMAGE_NT_SIGNATURE)
+                return FALSE;
 
-            if (MH_Initialize()                                                                   != MH_OK) return TRUE;
-            if (MH_CreateHook(pMainTarget, &DetourMain, reinterpret_cast<void**>(&pMainOriginal)) != MH_OK) return TRUE;
-            if (MH_EnableHook(pMainTarget)                                                        != MH_OK) return TRUE;
+            g_fnptr_main_target = reinterpret_cast<main_fn>(pMainModule + pImgNTHeaders->OptionalHeader.AddressOfEntryPoint);
+
+            if (MH_Initialize()                                                                                    != MH_OK
+            ||  MH_CreateHook(g_fnptr_main_target, &stage1_main, reinterpret_cast<void**>(&g_fnptr_main_original)) != MH_OK
+            ||  MH_EnableHook(g_fnptr_main_target)                                                                 != MH_OK)
+                return FALSE;
         }
         case DLL_THREAD_ATTACH:
         case DLL_THREAD_DETACH:
@@ -288,4 +425,3 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     }
     return TRUE;
 }
-

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -38,8 +38,7 @@ hostfxr_get_runtime_delegate_fn          g_fnptr_hostfxr_get_delegate;
 hostfxr_close_fn                         g_fnptr_hostfxr_close;
 
 // Using the nethost library, discover the location of hostfxr and get exports
-static bool
-load_hostfxr() {
+static bool load_hostfxr() {
     // Pre-allocate a large buffer for the path to hostfxr
     char_t buffer[MAX_PATH];
     size_t buffer_size = sizeof(buffer) / sizeof(char_t);
@@ -74,10 +73,9 @@ load_hostfxr() {
  * - https://www.debuginfo.com/examples/src/effminidumps/MiniDump.cpp
  */
 
-// Adapted from Dalamud under the terms of the AGPL
+// Since there is no reasonable general list of exceptions to exempt from VEH, I used Dalamud's.
 // https://github.com/goatcorp/Dalamud/blob/7e980a0a5e312c65d22f724703715e0679d2ef8a/Dalamud.Boot/veh.cpp#L40-L80
-static bool
-stage1_eh_whitelist_exception(const DWORD code)
+static bool stage1_eh_whitelist_exception(const DWORD code)
 {
     switch (code)
     {
@@ -121,20 +119,19 @@ stage1_eh_whitelist_exception(const DWORD code)
 }
 
 // Filters the core dump to exclude objects which we do not want to record.
-static BOOL CALLBACK
-stage1_eh_filter_dump(
-          PVOID                     CallbackParam,
-    const PMINIDUMP_CALLBACK_INPUT  CallbackInput,
-          PMINIDUMP_CALLBACK_OUTPUT CallbackOutput) {
-    if (!CallbackInput || !CallbackOutput) return FALSE;
+static BOOL CALLBACK stage1_eh_filter_dump(
+          PVOID                     ptr_callback_param,
+    const PMINIDUMP_CALLBACK_INPUT  ptr_callback_input,
+          PMINIDUMP_CALLBACK_OUTPUT ptr_callback_output) {
+    if (!ptr_callback_input || !ptr_callback_output) return FALSE;
 
-    switch (CallbackInput->CallbackType) {
+    switch (ptr_callback_input->CallbackType) {
         case CancelCallback:
             return FALSE;
 
         case IncludeThreadCallback: {
             // Exclude the thread which writes the minidump.
-            return CallbackInput->IncludeThread.ThreadId != g_eh_thread_handler_id;
+            return ptr_callback_input->IncludeThread.ThreadId != g_eh_thread_handler_id;
         } break;
     }
 
@@ -142,8 +139,7 @@ stage1_eh_filter_dump(
 }
 
 // Writes a customized core dump.
-static DWORD CALLBACK
-stage1_eh_create_dump(LPVOID lpThreadParameter) {
+static DWORD CALLBACK stage1_eh_create_dump(LPVOID ptr_thread_parameter) {
     HANDLE hFile = CreateFileW(
         L"crash_dump.dmp",
         GENERIC_READ | GENERIC_WRITE,
@@ -207,9 +203,8 @@ stage1_eh_create_dump(LPVOID lpThreadParameter) {
 }
 
 // The Stage1 exception handler.
-static LONG WINAPI
-stage1_eh(EXCEPTION_POINTERS* ExceptionInfo) {
-    g_eh_exception_ptr      = ExceptionInfo;
+static LONG WINAPI stage1_eh(EXCEPTION_POINTERS* ptr_exception_info) {
+    g_eh_exception_ptr      = ptr_exception_info;
     g_eh_thread_faulting_id = GetCurrentThreadId();
 
     ::ResumeThread       (g_eh_thread_handler);
@@ -220,10 +215,9 @@ stage1_eh(EXCEPTION_POINTERS* ExceptionInfo) {
 }
 
 // The Stage1 vectored exception handler.
-static LONG NTAPI
-stage1_veh(EXCEPTION_POINTERS* ExceptionInfo) {
+static LONG NTAPI stage1_veh(EXCEPTION_POINTERS* ptr_exception_info) {
     // TODO: remove logging after testruns
-    auto ec = ExceptionInfo->ExceptionRecord->ExceptionCode;
+    auto ec = ptr_exception_info->ExceptionRecord->ExceptionCode;
     std::wcout << "VEH: " << std::hex << ec << std::endl;
 
     /* [fkelava 15/06/26 00:43]
@@ -234,18 +228,16 @@ stage1_veh(EXCEPTION_POINTERS* ExceptionInfo) {
     if (ec < 0x80000000 || !stage1_eh_whitelist_exception(ec))
         return EXCEPTION_CONTINUE_SEARCH;
 
-    return stage1_eh(ExceptionInfo);
+    return stage1_eh(ptr_exception_info);
 }
 
 // Ignores the game's attempt to install its own exception handler.
-static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI
-stage1_eh_set_filter(_In_opt_ LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter) {
+static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI stage1_eh_set_filter(LPTOP_LEVEL_EXCEPTION_FILTER fnptr_exception_filter) {
     return &stage1_eh;
 }
 
 // If necessary, replaces the game's EH filter with a Stage1 custom one.
-static BOOL
-stage1_eh_install(LPBYTE pMainModule) {
+static BOOL stage1_eh_install(LPBYTE ptr_main_module) {
     char_t exe_full_name_buf[MAX_PATH];
     auto size = ::GetModuleFileNameW(NULL, exe_full_name_buf, sizeof(exe_full_name_buf) / sizeof(char_t));
 
@@ -291,8 +283,7 @@ stage1_eh_install(LPBYTE pMainModule) {
 }
 
 // Runs before the program's own entrypoint, setting up Fahrenheit.
-static int
-stage1_main(void) {
+static int stage1_main(void) {
     // STEP 1:
     // Attach to the Stage0 console and forward stdout/stderr to it.
     if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -371,9 +362,9 @@ stage1_main(void) {
 
     // STEP 6:
     // Initialize and start the .NET runtime.
-    void*          load_assembly_fptr        = nullptr;
-    void*          get_function_pointer_fptr = nullptr;
-    hostfxr_handle cxt                       = nullptr;
+    void*          ptr_hostfxr_load_assembly        = nullptr;
+    void*          ptr_hostfxr_get_function_pointer = nullptr;
+    hostfxr_handle cxt                              = nullptr;
 
     int rc = g_fnptr_hostfxr_init(clrhost_config_path.c_str(), nullptr, &cxt);
     if (rc != 0 || cxt == nullptr) {
@@ -389,9 +380,9 @@ stage1_main(void) {
     rc = g_fnptr_hostfxr_get_delegate(
         cxt,
         hdt_load_assembly,
-        &load_assembly_fptr);
+        &ptr_hostfxr_load_assembly);
 
-    if (rc != 0 || load_assembly_fptr == nullptr) {
+    if (rc != 0 || ptr_hostfxr_load_assembly == nullptr) {
         std::wcerr << "hostfxr: failed to obtain fnptr (hdt_load_assembly)" << std::endl;
         std::wcerr << "This is an uncommon error. Please contact the Fahrenheit developers at https://github.com/fahrenheit-crew/fahrenheit." << std::endl;
         exit(rc);
@@ -400,9 +391,9 @@ stage1_main(void) {
     rc = g_fnptr_hostfxr_get_delegate(
         cxt,
         hdt_get_function_pointer,
-        &get_function_pointer_fptr);
+        &ptr_hostfxr_get_function_pointer);
 
-    if (rc != 0 || get_function_pointer_fptr == nullptr) {
+    if (rc != 0 || ptr_hostfxr_get_function_pointer == nullptr) {
         std::wcerr << "hostfxr: failed to obtain fnptr (hdt_get_function_pointer)"  << std::endl;
         std::wcerr << "This is an uncommon error. Please contact the Fahrenheit developers at https://github.com/fahrenheit-crew/fahrenheit." << std::endl;
         exit(rc);
@@ -410,14 +401,14 @@ stage1_main(void) {
 
     g_fnptr_hostfxr_close(cxt);
 
-    load_assembly_fn        load_assembly        = (load_assembly_fn)       load_assembly_fptr;
-    get_function_pointer_fn get_function_pointer = (get_function_pointer_fn)get_function_pointer_fptr;
+    load_assembly_fn        fnptr_hostfxr_load_assembly        = (load_assembly_fn)       ptr_hostfxr_load_assembly;
+    get_function_pointer_fn fnptr_hostfxr_get_function_pointer = (get_function_pointer_fn)ptr_hostfxr_get_function_pointer;
 
     // STEP 8:
     // Load managed assembly and get function pointer to bootstrap function.
     fh_init fnptr_fh_init = nullptr;
 
-    rc = load_assembly(
+    rc = fnptr_hostfxr_load_assembly(
         clrhost_lib_path.c_str(),
         nullptr,
         nullptr);
@@ -428,7 +419,7 @@ stage1_main(void) {
         exit(rc);
     }
 
-    rc = get_function_pointer(
+    rc = fnptr_hostfxr_get_function_pointer(
         clrhost_type,
         clrhost_init_method,
         UNMANAGEDCALLERSONLY_METHOD,
@@ -464,12 +455,12 @@ stage1_main(void) {
     return g_fnptr_main_original();
 }
 
-BOOL APIENTRY
-DllMain( HMODULE hinstDLL,
-         DWORD   fdwReason,
-         LPVOID  lpvReserved
-         ) {
-    switch (fdwReason) {
+BOOL APIENTRY DllMain(
+    HMODULE hdll,
+    DWORD   reason,
+    LPVOID  ptr_reserved
+) {
+    switch (reason) {
         case DLL_PROCESS_ATTACH: {
             // Return the IAT to its original self.
             if (!DetourRestoreAfterWith())

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -7,6 +7,9 @@
  * For the exception handling, see:
  * - http://code.aaronballman.com/minidumper/MiniDump.cpp
  * - https://github.com/folgerwang/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp
+ * - https://github.com/goatcorp/Dalamud/blob/master/Dalamud.Boot/veh.cpp
+ *
+ * Portions of VEH handling (C) Dalamud, under the terms of the AGPL.
  */
 
 #include "fhstage1.h"
@@ -22,7 +25,6 @@ using eh_fn    = LONG(*)(EXCEPTION_POINTERS*);
 main_fn g_fnptr_main_original = nullptr;
 main_fn g_fnptr_main_target   = nullptr;
 eh_fn   g_fnptr_eh_original   = nullptr;
-eh_fn   g_fnptr_eh_target     = nullptr;
 
 // Globals for EH override
 DWORD               g_eh_thread_faulting_id;
@@ -36,7 +38,8 @@ hostfxr_get_runtime_delegate_fn          g_fnptr_hostfxr_get_delegate;
 hostfxr_close_fn                         g_fnptr_hostfxr_close;
 
 // Using the nethost library, discover the location of hostfxr and get exports
-static bool load_hostfxr() {
+static bool
+load_hostfxr() {
     // Pre-allocate a large buffer for the path to hostfxr
     char_t buffer[MAX_PATH];
     size_t buffer_size = sizeof(buffer) / sizeof(char_t);
@@ -64,8 +67,6 @@ static bool load_hostfxr() {
  * An exception handler which behaves the same as the game's,
  * except that it _unconditionally_ emits a customized core dump.
  *
- * We catch managed exceptions in C#, and this filter catches native or fatal exceptions for logging.
- *
  * See:
  * - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
  * - https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-unhandledexceptionfilter
@@ -73,8 +74,55 @@ static bool load_hostfxr() {
  * - https://www.debuginfo.com/examples/src/effminidumps/MiniDump.cpp
  */
 
+// Adapted from Dalamud under the terms of the AGPL
+// https://github.com/goatcorp/Dalamud/blob/7e980a0a5e312c65d22f724703715e0679d2ef8a/Dalamud.Boot/veh.cpp#L40-L80
+static bool
+stage1_eh_whitelist_exception(const DWORD code)
+{
+    switch (code)
+    {
+        case STATUS_ACCESS_VIOLATION:
+        case STATUS_IN_PAGE_ERROR:
+        case STATUS_INVALID_HANDLE:
+        case STATUS_INVALID_PARAMETER:
+        case STATUS_NO_MEMORY:
+        case STATUS_ILLEGAL_INSTRUCTION:
+        case STATUS_NONCONTINUABLE_EXCEPTION:
+        case STATUS_INVALID_DISPOSITION:
+        case STATUS_ARRAY_BOUNDS_EXCEEDED:
+        case STATUS_FLOAT_DENORMAL_OPERAND:
+        case STATUS_FLOAT_DIVIDE_BY_ZERO:
+        case STATUS_FLOAT_INEXACT_RESULT:
+        case STATUS_FLOAT_INVALID_OPERATION:
+        case STATUS_FLOAT_OVERFLOW:
+        case STATUS_FLOAT_STACK_CHECK:
+        case STATUS_FLOAT_UNDERFLOW:
+        case STATUS_INTEGER_DIVIDE_BY_ZERO:
+        case STATUS_INTEGER_OVERFLOW:
+        case STATUS_PRIVILEGED_INSTRUCTION:
+        case STATUS_STACK_OVERFLOW:
+        case STATUS_DLL_NOT_FOUND:
+        case STATUS_ORDINAL_NOT_FOUND:
+        case STATUS_ENTRYPOINT_NOT_FOUND:
+        case STATUS_DLL_INIT_FAILED:
+        case STATUS_CONTROL_STACK_VIOLATION:
+        case STATUS_FLOAT_MULTIPLE_FAULTS:
+        case STATUS_FLOAT_MULTIPLE_TRAPS:
+        case STATUS_HEAP_CORRUPTION:
+        case STATUS_STACK_BUFFER_OVERRUN:
+        case STATUS_INVALID_CRUNTIME_PARAMETER:
+        case STATUS_THREAD_NOT_RUNNING:
+        case STATUS_ALREADY_REGISTERED:
+        case 0xE0434352: // CLR exception
+            return true;
+        default:
+            return false;
+    }
+}
+
 // Filters the core dump to exclude objects which we do not want to record.
-static BOOL CALLBACK stage1_eh_filter_dump(
+static BOOL CALLBACK
+stage1_eh_filter_dump(
           PVOID                     CallbackParam,
     const PMINIDUMP_CALLBACK_INPUT  CallbackInput,
           PMINIDUMP_CALLBACK_OUTPUT CallbackOutput) {
@@ -86,7 +134,7 @@ static BOOL CALLBACK stage1_eh_filter_dump(
 
         case IncludeThreadCallback: {
             // Exclude the thread which writes the minidump.
-            return CallbackInput->IncludeThread.ThreadId != g_eh_thread_handler_id;
+            return CallbackInput->Thread.ThreadId != g_eh_thread_handler_id;
         } break;
     }
 
@@ -94,7 +142,8 @@ static BOOL CALLBACK stage1_eh_filter_dump(
 }
 
 // Writes a customized core dump.
-static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
+static DWORD CALLBACK
+stage1_eh_create_dump(LPVOID lpThreadParameter) {
     HANDLE hFile = CreateFileW(
         L"crash_dump.dmp",
         GENERIC_READ | GENERIC_WRITE,
@@ -112,11 +161,13 @@ static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
     HANDLE        hProcess  = GetCurrentProcess();
     DWORD         ProcessId = GetProcessId(hProcess);
     MINIDUMP_TYPE DumpType  = (MINIDUMP_TYPE)(
-                              MiniDumpWithThreadInfo
-                            | MiniDumpWithFullMemoryInfo
-                            | MiniDumpWithProcessThreadData
+                              MiniDumpNormal
+                            | MiniDumpWithDataSegs
                             | MiniDumpWithHandleData
-                            | MiniDumpWithDataSegs);
+                            | MiniDumpWithFullMemoryInfo
+                            | MiniDumpWithThreadInfo
+                            | MiniDumpWithProcessThreadData
+                            | MiniDumpWithUnloadedModules);
 
     /* [fkelava 11/06/26 21:24]
      * For ClientPointers:
@@ -132,8 +183,10 @@ static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
     mci.CallbackRoutine = (MINIDUMP_CALLBACK_ROUTINE)stage1_eh_filter_dump;
     mci.CallbackParam   = nullptr;
 
-    PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam = g_eh_exception_ptr != 0 ? &mdei : nullptr;
+    PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam = g_eh_exception_ptr != nullptr ? &mdei : nullptr;
     PMINIDUMP_CALLBACK_INFORMATION  CallbackParam  = &mci;
+
+    std::wcerr << "Dumping process core. Please wait." << std::endl;
 
     BOOL rv = MiniDumpWriteDump(
         hProcess,
@@ -154,19 +207,45 @@ static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
 }
 
 // The Stage1 exception handler.
-static LONG WINAPI stage1_eh(EXCEPTION_POINTERS* ExceptionInfo) {
+static LONG WINAPI
+stage1_eh(EXCEPTION_POINTERS* ExceptionInfo) {
     g_eh_exception_ptr      = ExceptionInfo;
     g_eh_thread_faulting_id = GetCurrentThreadId();
 
-    ::ResumeThread(g_eh_thread_handler);
+    ::ResumeThread       (g_eh_thread_handler);
     ::WaitForSingleObject(g_eh_thread_handler, INFINITE);
-    ::CloseHandle(g_eh_thread_handler);
+    ::CloseHandle        (g_eh_thread_handler);
 
-    return EXCEPTION_EXECUTE_HANDLER;
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+// The Stage1 vectored exception handler.
+static LONG NTAPI
+stage1_veh(EXCEPTION_POINTERS* ExceptionInfo) {
+    // TODO: remove logging after testruns
+    auto ec = ExceptionInfo->ExceptionRecord->ExceptionCode;
+    std::wcout << "VEH: " << std::hex << ec << std::endl;
+
+    /* [fkelava 15/06/26 00:43]
+     * Per Passant (https://stackoverflow.com/a/12300563):
+     * > Exception codes with values less than 0x80000000 are
+     * > just informal and never an indicator of real trouble.
+     */
+    if (ec < 0x80000000 || !stage1_eh_whitelist_exception(ec))
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    return stage1_eh(ExceptionInfo);
+}
+
+// Ignores the game's attempt to install its own exception handler.
+static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI
+stage1_eh_set_filter(_In_opt_ LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter) {
+    return &stage1_eh;
 }
 
 // If necessary, replaces the game's EH filter with a Stage1 custom one.
-static BOOL stage1_eh_install(LPBYTE pMainModule) {
+static BOOL
+stage1_eh_install(LPBYTE pMainModule) {
     char_t exe_full_name_buf[MAX_PATH];
     auto size = ::GetModuleFileNameW(NULL, exe_full_name_buf, sizeof(exe_full_name_buf) / sizeof(char_t));
 
@@ -181,43 +260,39 @@ static BOOL stage1_eh_install(LPBYTE pMainModule) {
     string_t exe_name = exe_full_name.substr(exe_name_dirsep_pos, exe_full_name.length());
 
     // This can be generalized for other games in the future.
-    bool is_ffx            = exe_name.compare(L"FFX.exe")   == 0;
-    bool is_ffx2           = exe_name.compare(L"FFX-2.exe") == 0;
-    bool should_install_eh = is_ffx || is_ffx2;
+    if (exe_name.compare(L"FFX.exe")   != 0
+    &&  exe_name.compare(L"FFX-2.exe") != 0)
+        return TRUE;
 
-    if (should_install_eh) {
-        std::wcout << "Installing EH hook for " << exe_name << std::endl;
+    g_eh_thread_handler = ::CreateThread(
+        nullptr,
+        0,
+        stage1_eh_create_dump,
+        nullptr,
+        CREATE_SUSPENDED,
+        &g_eh_thread_handler_id);
 
-        auto eh_offset = is_ffx ? 0x226A90 : 0x6B6340;
-        g_fnptr_eh_target = reinterpret_cast<eh_fn>(pMainModule + eh_offset);
-
-        if (MH_CreateHook(g_fnptr_eh_target, &stage1_eh, reinterpret_cast<void**>(&g_fnptr_eh_original)) != MH_OK
-        ||  MH_EnableHook(g_fnptr_eh_target)                                                             != MH_OK) {
-            std::wcerr << "Failed to insert EH hook for " << exe_name << std::endl;
-            return FALSE;
-        }
-
-        g_eh_thread_handler = ::CreateThread(
-            nullptr,
-            0,
-            stage1_eh_create_dump,
-            nullptr,
-            CREATE_SUSPENDED,
-            &g_eh_thread_handler_id);
-
-        if (g_eh_thread_handler == nullptr || g_eh_thread_handler == INVALID_HANDLE_VALUE) {
-            std::wcerr << "Failed to create EH thread for " << exe_name << std::endl;
-            return FALSE;
-        }
-
-        ::SetThreadDescription(g_eh_thread_handler, L"Fahrenheit EH");
+    if (g_eh_thread_handler == nullptr || g_eh_thread_handler == INVALID_HANDLE_VALUE) {
+        std::wcerr << "Failed to create EH thread for " << exe_name << std::endl;
+        return FALSE;
     }
 
+    ::SetThreadDescription(g_eh_thread_handler, L"Fahrenheit EH");
+    AddVectoredExceptionHandler(TRUE, &stage1_veh);
+
+    if (MH_CreateHookApi(L"kernel32.dll", "SetUnhandledExceptionFilter", &stage1_eh_set_filter, reinterpret_cast<void**>(&g_fnptr_eh_original)) != MH_OK
+    ||  MH_EnableHook   (&SetUnhandledExceptionFilter)                                                                                          != MH_OK) {
+        std::wcerr << "Failed to install EH hook for " << exe_name << std::endl;
+        return FALSE;
+    }
+
+    std::wcout << "Installed EH hook for " << exe_name << std::endl;
     return TRUE;
 }
 
 // Runs before the program's own entrypoint, setting up Fahrenheit.
-static int stage1_main(void) {
+static int
+stage1_main(void) {
     // STEP 1:
     // Attach to the Stage0 console and forward stdout/stderr to it.
     if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -241,7 +316,7 @@ static int stage1_main(void) {
     LPBYTE  pMainModule = reinterpret_cast<LPBYTE>(hMainModule);
 
     if (!stage1_eh_install(pMainModule)) {
-        std::wcerr << "Failed to insert EH hook." << std::endl;
+        std::wcerr << "Failed to install EH hook." << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -389,10 +464,11 @@ static int stage1_main(void) {
     return g_fnptr_main_original();
 }
 
-BOOL APIENTRY DllMain( HMODULE hinstDLL,
-                       DWORD   fdwReason,
-                       LPVOID  lpvReserved
-                     ) {
+BOOL APIENTRY
+DllMain( HMODULE hinstDLL,
+         DWORD   fdwReason,
+         LPVOID  lpvReserved
+         ) {
     switch (fdwReason) {
         case DLL_PROCESS_ATTACH: {
             // Return the IAT to its original self.

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -96,7 +96,7 @@ static BOOL CALLBACK stage1_eh_filter_dump(
 // Writes a customized core dump.
 static DWORD CALLBACK stage1_eh_create_dump(LPVOID lpThreadParameter) {
     HANDLE hFile = CreateFileW(
-        L"fahrenheit.dmp",
+        L"crash_dump.dmp",
         GENERIC_READ | GENERIC_WRITE,
         0,
         nullptr,


### PR DESCRIPTION
Contributes to #162.

#168 added limited exception logging on the managed side. This is, by design, limited to non-fatal managed exceptions. However, we have a vested interest in capturing _all_ exceptions, including such things as AVs.

For this, we have to resort to native exception handling. We override the game's own unhandled exception filter (https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-unhandledexceptionfilter, https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setunhandledexceptionfilter) to substitute our own. This has a dual effect:
- we can control the exact dumping behavior
- we avoid a case where the games refuse to dump core

The resulting dumps _seem_ fine, but Visual Studio sometimes has issues reconstructing mixed frames. There is also the open question of whether this will improve the dump debugging experience under WINE/Proton. WinDbg on Windows- the primary tool for heavyweight debugging- accepts these dumps as they are. We should move forward with testing.

The correctness should be vetted in an actual project on a variety of systems because unlike the managed side, things can go _badly_ wrong here.