### PR TITLE
Lift the save manager and local state machinery into Core

### DIFF
--- a/src/core/api.cs
+++ b/src/core/api.cs
@@ -34,5 +34,7 @@ internal static class FhInternal {
     public static readonly FhLoader      Loader      = new FhLoader();
     public static readonly FhMethodTable MethodTable = new FhMethodTable();
     public static readonly FhHasher      Hasher      = new FhHasher();
+    public static readonly FhState       State       = new();
+    public static readonly FhSaves       Saves       = new();
     public static readonly FhSettings    Settings    = new();
 }

--- a/src/core/save_mgr.cs
+++ b/src/core/save_mgr.cs
@@ -8,7 +8,6 @@ namespace Fahrenheit;
 /// <summary>
 ///     Allows multiple sets of saves to exist.
 /// </summary>
-[FhLoad(FhGameId.FFX | FhGameId.FFX2 | FhGameId.FFX2LM)]
 internal sealed class FhSaves {
 
     /* [fkelava 07/11/25 15:01]

--- a/src/core/save_mgr.cs
+++ b/src/core/save_mgr.cs
@@ -3,15 +3,13 @@
 // This file is part of Fahrenheit, © 2023-2026 The Fahrenheit contributors.
 // It is licensed to you under the GNU Lesser General Public License, version 3.0 or later. See COPYING, COPYING.LESSER.
 
-using System.Diagnostics;
-
-namespace Fahrenheit.Runtime;
+namespace Fahrenheit;
 
 /// <summary>
 ///     Allows multiple sets of saves to exist.
 /// </summary>
 [FhLoad(FhGameId.FFX | FhGameId.FFX2 | FhGameId.FFX2LM)]
-public sealed class FhSaveManagerModule : FhModule {
+internal sealed class FhSaves {
 
     /* [fkelava 07/11/25 15:01]
      * Fh computes a load-order sensitive hash over all mods that declare 'separate saves'.
@@ -31,7 +29,7 @@ public sealed class FhSaveManagerModule : FhModule {
     private readonly FhSaveDisplayData[]            _sm_display_data;
     private readonly Dictionary<string, FileInfo[]> _sm_file_attributes;
 
-    public FhSaveManagerModule() {
+    public FhSaves() {
         _sm_path_base        = Path.Join(FhEnvironment.Finder.Saves.FullName, FhInternal.Hasher.SaveSetHash);
         _sm_path_default_set = Path.Join(_sm_path_base, FhSavePal.DEFAULT_SET_NAME, FhSavePal.pal_get_save_subfolder());
         _sm_sets             = [];
@@ -41,11 +39,6 @@ public sealed class FhSaveManagerModule : FhModule {
         _sm_active_set_saves = new int              [_sm_set_size];
         _sm_display_data     = new FhSaveDisplayData[_sm_set_size];
         _sm_file_attributes  = [];
-    }
-
-    public override bool init(FhModContext mod_context, FileStream global_state_file) {
-        _sm_create_default_set();
-        _sm_query_sets();
 
         /* [fkelava 19/01/26 18:13]
          * Save PAL is not ready to perform indexing operations at 'init' time because
@@ -54,7 +47,8 @@ public sealed class FhSaveManagerModule : FhModule {
          * Set indexing is performed just in time when SEM transitions to save/load mode.
          */
 
-        return true;
+        _sm_create_default_set();
+        _sm_query_sets();
     }
 
     /* [fkelava 19/01/26 12:03]
@@ -165,12 +159,12 @@ public sealed class FhSaveManagerModule : FhModule {
          */
 
         if (!_sm_sets.Contains(_sm_active_set)) {
-            _logger.Warning($"Active set {_sm_active_set} was deleted; falling back to default.");
+            FhInternal.Log.Warning($"Active set {_sm_active_set} was deleted; falling back to default.");
             _sm_active_set = FhSavePal.DEFAULT_SET_NAME;
         }
 
         if (!_sm_sets.Contains(FhSavePal.DEFAULT_SET_NAME)) {
-            _logger.Error("Default set was deleted; forcibly re-generating.");
+            FhInternal.Log.Error("Default set was deleted; forcibly re-generating.");
 
             _sm_create_default_set();
             _sm_query_sets();

--- a/src/core/save_pal.cs
+++ b/src/core/save_pal.cs
@@ -201,6 +201,39 @@ internal struct FhSaveHeader2 {
     public byte   _0x2C;
 }
 
+/// <summary>
+///     Contains the fields the game shows as part of its standard save game display.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct FhSaveDisplayData {
+
+    /* [fkelava 19/01/26 13:14]
+     * An array of these of size DEFAULT_SET_SIZE is allocated by the save UI module on boot.
+     * These instances are continually reused. To prevent garbage from being displayed when a slot
+     * occupied in the previous set becomes empty, the save manager module (un)sets 'valid'.
+     *
+     * These inline arrays are in reality UTF-8 strings, since both Iggy
+     * and ImGui accept them as input. The sizes are taken from the base game.
+     */
+
+    internal bool valid;
+
+    public InlineArray64 <byte> header;
+    public InlineArray16 <byte> slot;
+    public InlineArray64 <byte> create_time;
+    public InlineArray128<byte> location;
+    public InlineArray128<byte> play_time;
+    public InlineArray32 <byte> player_name;
+    public InlineArray16 <byte> icon_chr1;
+    public InlineArray16 <byte> icon_chr2;
+    public InlineArray16 <byte> icon_chr3;
+    public InlineArray16 <byte> icon_map;
+    public InlineArray128<byte> chapter;
+    public InlineArray128<byte> completion;
+    public InlineArray64 <byte> lm_level;
+    public InlineArray64 <byte> lm_job;
+}
+
 /* [fkelava 10/01/26 16:53]
  * The save PAL, being a binding to implementation details of each game,
  * is virtually illegible without consulting the original method bodies.

--- a/src/core/state.cs
+++ b/src/core/state.cs
@@ -3,7 +3,7 @@
 // This file is part of Fahrenheit, © 2023-2026 The Fahrenheit contributors.
 // It is licensed to you under the GNU Lesser General Public License, version 3.0 or later. See COPYING, COPYING.LESSER.
 
-namespace Fahrenheit.Runtime;
+namespace Fahrenheit;
 
 /* [fkelava 23/02/26 16:59]
  * Mods must be able to persist some information between saves or game sessions.
@@ -24,18 +24,7 @@ namespace Fahrenheit.Runtime;
 ///     In your module, implement <see cref="FhModule.load_local_state(FileStream, FhLocalStateInfo)"/>
 ///     and <see cref="FhModule.save_local_state(FileStream)"/>.
 /// </summary>
-[FhLoad(FhGameId.FFX | FhGameId.FFX2 | FhGameId.FFX2LM)]
-public sealed class FhLocalStateModule : FhModule {
-
-    private FhSaveManagerModule? _smm;
-
-    public FhLocalStateModule() { }
-
-    public override bool init(FhModContext mod_context, FileStream global_state_file) {
-        FhModuleHandle<FhSaveManagerModule> handle_smm = new(this);
-
-        return handle_smm.try_get_module(out _smm);
-    }
+internal sealed class FhState {
 
     /// <summary>
     ///     For the given save <paramref name="slot"/> and given module's <paramref name="module_context"/>,
@@ -45,7 +34,7 @@ public sealed class FhLocalStateModule : FhModule {
         string local_state_dir = Path.Join(
             FhEnvironment.Finder.State.FullName,
             FhInternal.Hasher.SaveSetHash,
-            _smm!.get_active_set(),
+            FhInternal.Saves.get_active_set(),
             FhSavePal.pal_get_save_subfolder(),
             FhSavePal.pal_get_save_name_for_slot(slot),
             mod_context.Manifest.Id,
@@ -72,11 +61,11 @@ public sealed class FhLocalStateModule : FhModule {
                 using FileStream state_meta_fs = File.Open(state_meta_fn, FileMode.Open,         FileAccess.Read, FileShare.None);
                 using FileStream state_fs      = File.Open(state_fn,      FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read);
 
-                _logger.Debug($"Reading metadata for module {module_type}.");
+                FhInternal.Log.Debug($"Reading metadata for module {module_type}.");
                 FhLocalStateInfo state_meta = JsonSerializer.Deserialize<FhLocalStateInfo>(state_meta_fs, FhUtil.InternalJsonOpts)
                     ?? throw new Exception("FH_E_LOCAL_STATE_META_BLOCK_NULL");
 
-                _logger.Debug($"{state_fn} -> {module_type}.");
+                FhInternal.Log.Debug($"{state_fn} -> {module_type}.");
                 module_context.Module.load_local_state(state_fs, state_meta);
             }
         }
@@ -99,12 +88,13 @@ public sealed class FhLocalStateModule : FhModule {
                 using FileStream state_meta_fs = File.Open(state_meta_fn, FileMode.Create,       FileAccess.Write, FileShare.None);
                 using FileStream state_fs      = File.Open(state_fn,      FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
 
-                _logger.Debug($"Writing metadata for module {module_type}.");
+                FhInternal.Log.Debug($"Writing metadata for module {module_type}.");
                 state_meta_fs.Write(JsonSerializer.SerializeToUtf8Bytes(state_meta, FhUtil.InternalJsonOpts));
 
-                _logger.Debug($"{module_type} -> {state_fn}.");
+                FhInternal.Log.Debug($"{module_type} -> {state_fn}.");
                 module_context.Module.save_local_state(state_fs);
             }
         }
     }
+
 }

--- a/src/core/state.cs
+++ b/src/core/state.cs
@@ -96,5 +96,4 @@ internal sealed class FhState {
             }
         }
     }
-
 }

--- a/src/runtime/save_impl.cs
+++ b/src/runtime/save_impl.cs
@@ -31,26 +31,19 @@ internal enum FhSaveExtensionSystemState {
 [FhLoad(FhGameId.FFX | FhGameId.FFX2 | FhGameId.FFX2LM)]
 public unsafe sealed class FhSaveExtensionModule : FhModule {
 
-    private FhLocalStateModule?        _lsm;
-    private FhSaveManagerModule?       _smm;
     private int                        _load_pending_slot;
     private FhSaveExtensionSystemState _state;
 
     public FhSaveExtensionModule() { }
 
     public override bool init(FhModContext mod_context, FileStream global_state_file) {
-        FhModuleHandle<FhLocalStateModule>  lsm_handle = new(this);
-        FhModuleHandle<FhSaveManagerModule> smm_handle = new(this);
-
         bool is_ffx = FhGlobal.game_id is FhGameId.FFX;
 
         return FhCall.h_SaveDataManager_debugSave_Internal_6F0650.hook(this, impl_autosave)
             && FhCall.h_TkMenuJumpToLoadedScene                  .hook(this, impl_copy)
             && FhCall.h_SaveDataToSave                           .hook(this, signal_enter_save)
             && FhCall.h_SaveDataToLoad                           .hook(this, signal_enter_load)
-            && (!is_ffx || FFX.FhCall.h_FUN_2EFFF0.hook(this, signal_enter_albd))
-            && lsm_handle.try_get_module(out _lsm)
-            && smm_handle.try_get_module(out _smm);
+            && (!is_ffx || FFX.FhCall.h_FUN_2EFFF0.hook(this, signal_enter_albd));
     }
 
     internal FhSaveExtensionSystemState get_system_state() => _state;
@@ -72,7 +65,7 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     /// </summary>
     [UnmanagedCallConv(CallConvs = [ typeof(CallConvCdecl) ] )]
     private void signal_enter_save() {
-        _smm!.index_active_set();
+        FhInternal.Saves.index_active_set();
         _state = FhSaveExtensionSystemState.SAVE;
         FhSavePal.pal_set_system_state(FhSaveSystemState.SAVE);
     }
@@ -82,7 +75,7 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     /// </summary>
     [UnmanagedCallConv(CallConvs = [ typeof(CallConvCdecl) ] )]
     private void signal_enter_load() {
-        _smm!.index_active_set();
+        FhInternal.Saves.index_active_set();
         _state = FhSaveExtensionSystemState.LOAD;
         FhSavePal.pal_set_system_state(FhSaveSystemState.LOAD);
     }
@@ -93,7 +86,7 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     /// </summary>
     [UnmanagedCallConv(CallConvs = [ typeof(CallConvCdecl ) ] )]
     private void signal_enter_albd() {
-        _smm!.index_active_set();
+        FhInternal.Saves.index_active_set();
         _state = FhSaveExtensionSystemState.ALBD;
         FhSavePal.pal_set_system_state(FhSaveSystemState.LOAD);
     }
@@ -145,7 +138,7 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     [UnmanagedCallConv(CallConvs = [ typeof(CallConvStdcall) ] )]
     private void impl_copy() {
         FhCall.h_TkMenuJumpToLoadedScene.chain_from(impl_copy).fnptr!();
-        _lsm!.state_load_slot(_load_pending_slot);
+        FhInternal.State.state_load_slot(_load_pending_slot);
 
         FhApi.Events.Common.GameLoop.PostLoadGame.invoke(new() { save_slot_idx = _load_pending_slot });
     }
@@ -158,14 +151,14 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
         FhCall.h_SaveDataWriteCrc       .fnptr!(ptr);
         FhCall.h__SetUpDefaultSaveFolder.fnptr!();
 
-        string             save_path = _smm!.get_save_path_for_slot(0);
+        string             save_path = FhInternal.Saves.get_save_path_for_slot(0);
         ReadOnlySpan<byte> save      = new(ptr, size);
 
         using (FileStream save_stream = File.OpenWrite(save_path)) {
             save_stream.Write(save);
         }
 
-        _lsm!.state_save_slot(0);
+        FhInternal.State.state_save_slot(0);
     }
 
     /* [fkelava 19/01/26 16:12]
@@ -181,8 +174,8 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     ///     selected <paramref name="index"/> in the save/load menu.
     /// </summary>
     internal void save(int index) {
-        int    slot      = _smm!.get_slot_save(index);
-        string save_path = _smm!.get_save_path_for_slot(slot);
+        int    slot      = FhInternal.Saves.get_slot_save(index);
+        string save_path = FhInternal.Saves.get_save_path_for_slot(slot);
 
         ReadOnlySpan<byte> save = new(FhSavePal.pal_addr_buf_save(), FhSavePal.pal_sz_buf_save());
         FhCall.h_SaveDataWriteCrc.fnptr!(FhSavePal.pal_addr_buf_save());
@@ -193,7 +186,7 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
             save_stream.Write(save);
         }
 
-        _lsm!.state_save_slot(slot);
+        FhInternal.State.state_save_slot(slot);
         signal_exit_success();
     }
 
@@ -202,8 +195,8 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     ///     selected <paramref name="index"/> in the save/load menu.
     /// </summary>
     internal void load(int index) {
-        int    slot      = _smm!.get_slot_load(index);
-        string save_name = _smm!.get_save_path_for_slot(slot);
+        int    slot      = FhInternal.Saves.get_slot_load(index);
+        string save_name = FhInternal.Saves.get_save_path_for_slot(slot);
 
         Span<byte> save = new(FhSavePal.pal_addr_buf_save(), FhSavePal.pal_sz_buf_save());
 
@@ -234,8 +227,8 @@ public unsafe sealed class FhSaveExtensionModule : FhModule {
     ///     at the given <paramref name="index"/> in the save/load menu.
     /// </summary>
     internal void load_albd(int index) {
-        int    slot      = _smm!.get_slot_load(index);
-        string save_name = _smm!.get_save_path_for_slot(slot);
+        int    slot      = FhInternal.Saves.get_slot_load(index);
+        string save_name = FhInternal.Saves.get_save_path_for_slot(slot);
 
         //Span<byte> save = new(
         //    FhUtil.ptr_at<byte>(pal_addr_buf_save()),

--- a/src/runtime/save_ui.cs
+++ b/src/runtime/save_ui.cs
@@ -17,39 +17,6 @@ namespace Fahrenheit.Runtime;
  */
 
 /// <summary>
-///     Contains the fields the game shows as part of its standard save game display.
-/// </summary>
-[StructLayout(LayoutKind.Sequential)]
-internal struct FhSaveDisplayData {
-
-    /* [fkelava 19/01/26 13:14]
-     * An array of these of size DEFAULT_SET_SIZE is allocated by the save UI module on boot.
-     * These instances are continually reused. To prevent garbage from being displayed when a slot
-     * occupied in the previous set becomes empty, the save manager module (un)sets 'valid'.
-     *
-     * These inline arrays are in reality UTF-8 strings, since both Iggy
-     * and ImGui accept them as input. The sizes are taken from the base game.
-     */
-
-    internal bool valid;
-
-    public InlineArray64 <byte> header;
-    public InlineArray16 <byte> slot;
-    public InlineArray64 <byte> create_time;
-    public InlineArray128<byte> location;
-    public InlineArray128<byte> play_time;
-    public InlineArray32 <byte> player_name;
-    public InlineArray16 <byte> icon_chr1;
-    public InlineArray16 <byte> icon_chr2;
-    public InlineArray16 <byte> icon_chr3;
-    public InlineArray16 <byte> icon_map;
-    public InlineArray128<byte> chapter;
-    public InlineArray128<byte> completion;
-    public InlineArray64 <byte> lm_level;
-    public InlineArray64 <byte> lm_job;
-}
-
-/// <summary>
 ///     Implements Fahrenheit's replacement save/load user interface.
 /// </summary>
 [FhLoad(FhGameId.FFX | FhGameId.FFX2 | FhGameId.FFX2LM)]
@@ -57,8 +24,6 @@ public sealed class FhSaveUiModule : FhModule {
 
     private readonly FhModuleHandle<FhSaveExtensionModule> _sem_handle;
     private          FhSaveExtensionModule?                _sem;
-    private readonly FhModuleHandle<FhSaveManagerModule>   _smm_handle;
-    private          FhSaveManagerModule?                  _smm;
 
     private int                   _display_index;
     private IReadOnlySet<string>? _sets;
@@ -66,12 +31,10 @@ public sealed class FhSaveUiModule : FhModule {
 
     public FhSaveUiModule() {
         _sem_handle = new(this);
-        _smm_handle = new(this);
     }
 
     public override bool init(FhModContext mod_context, FileStream global_state_file) {
-        return _sem_handle.try_get_module(out _sem)
-            && _smm_handle.try_get_module(out _smm);
+        return _sem_handle.try_get_module(out _sem);
     }
 
     public override void render_imgui() {
@@ -107,7 +70,7 @@ public sealed class FhSaveUiModule : FhModule {
 
         int slot = 0;
         if (_sem!.get_system_state() is FhSaveExtensionSystemState.SAVE) {
-            if (_smm!.get_slots_used() < _smm!.get_slots_total()) {
+            if (FhInternal.Saves.get_slots_used() < FhInternal.Saves.get_slots_total()) {
                 Vector2 size_new_save_btn = new(ImGui.GetContentRegionAvail().X, 0F);
 
                 if (ImGui.Button("New Save Data", size_new_save_btn)) {
@@ -118,9 +81,9 @@ public sealed class FhSaveUiModule : FhModule {
             slot = 1;
         }
 
-        ReadOnlySpan<FhSaveDisplayData> display_data = _smm!.get_display_data();
+        ReadOnlySpan<FhSaveDisplayData> display_data = FhInternal.Saves.get_display_data();
 
-        for (; slot < _smm!.get_slots_total(); slot++) {
+        for (; slot < FhInternal.Saves.get_slots_total(); slot++) {
             if (display_data[slot].valid) {
                 ui_savefile(slot, display_data[slot]);
             }
@@ -144,8 +107,8 @@ public sealed class FhSaveUiModule : FhModule {
             return;
         }
 
-        string active_set      = _smm!.get_active_set();
-        string slots_text      = $"({_smm!.get_slots_used()}/{_smm!.get_slots_total()})";
+        string active_set      = FhInternal.Saves.get_active_set();
+        string slots_text      = $"({FhInternal.Saves.get_slots_used()}/{FhInternal.Saves.get_slots_total()})";
         string active_set_text = $"{active_set} {slots_text}";
 
         float width_window = ImGui.GetWindowSize().X;
@@ -162,7 +125,7 @@ public sealed class FhSaveUiModule : FhModule {
              * It is important to only retrieve values from it once, not every frame.
              */
 
-            _sets = _smm!.get_sets();
+            _sets = FhInternal.Saves.get_sets();
             ImGui.OpenPopup("Select Set"u8);
         }
 
@@ -174,7 +137,7 @@ public sealed class FhSaveUiModule : FhModule {
                 bool is_selected = set == active_set;
 
                 if (ImGui.Selectable(set, is_selected)) {
-                    _smm!.switch_active_set(set);
+                    FhInternal.Saves.switch_active_set(set);
                     ImGui.CloseCurrentPopup();
                 }
 


### PR DESCRIPTION
Fixes #201.

Note that this still does not give sets proper Core 'API'- that is still blocked on modal permission requests (see #140), but at least it clarifies where these pieces properly belong.