### PR TITLE
More miscellaneous cleanup for `alpha11`

### DIFF
--- a/src/core/resload.cs
+++ b/src/core/resload.cs
@@ -3,8 +3,6 @@
 // This file is part of Fahrenheit, © 2023-2026 The Fahrenheit contributors.
 // It is licensed to you under the GNU Lesser General Public License, version 3.0 or later. See COPYING, COPYING.LESSER.
 
-using Hexa.NET.ImGui;
-
 namespace Fahrenheit;
 
 /// <summary>
@@ -109,13 +107,18 @@ public sealed record FhTexture(string path, FhTextureType type) {
     ///     A spurious unload will throw.
     /// </remarks>
     [SupportedOSPlatform("windows6.1")]
-    internal unsafe void unload() {
+    internal void unload() {
         /* [fkelava 01/05/26 18:51]
-         * Testing the return value is meaningless because it is not guaranteed to be precise.
-         *
+         * Testing the return value of Release is meaningless because it is not guaranteed to be precise.
          * If you believe you're leaking textures, turn on the D3D debug layer instead.
+         *
+         * SAFETY: cast of opaque 'ImTextureID' to true underlying type 'ID3D11ShaderResourceView' is well defined
+         * see: https://github.com/ocornut/imgui/blob/da137cbbb066e57f4b44f3f331c36e1e30e1cbe2/backends/imgui_impl_dx11.cpp#L5
+         * > {...} Use 'ID3D11ShaderResourceView*' as texture identifier. {...}
          */
-        ((ID3D11ShaderResourceView*)(void*)_tex_ref.GetTexID())->Release();
+        unsafe {
+            ((ID3D11ShaderResourceView*)(void*)_tex_ref.GetTexID())->Release();
+        }
 
         _tex_ref      = default;
         _tex_metadata = default;

--- a/src/core/resload.cs
+++ b/src/core/resload.cs
@@ -109,14 +109,15 @@ public sealed record FhTexture(string path, FhTextureType type) {
     [SupportedOSPlatform("windows6.1")]
     internal void unload() {
         /* [fkelava 01/05/26 18:51]
-         * Testing the return value of Release is meaningless because it is not guaranteed to be precise.
-         * If you believe you're leaking textures, turn on the D3D debug layer instead.
-         *
          * SAFETY: cast of opaque 'ImTextureID' to true underlying type 'ID3D11ShaderResourceView' is well defined
          * see: https://github.com/ocornut/imgui/blob/da137cbbb066e57f4b44f3f331c36e1e30e1cbe2/backends/imgui_impl_dx11.cpp#L5
          * > {...} Use 'ID3D11ShaderResourceView*' as texture identifier. {...}
          */
         unsafe {
+            /* [fkelava 14/07/26 18:42]
+             * Testing the return value of Release is meaningless because it is not guaranteed to be precise.
+             * If you believe you're leaking textures, turn on the D3D debug layer instead.
+             */
             ((ID3D11ShaderResourceView*)(void*)_tex_ref.GetTexID())->Release();
         }
 

--- a/src/step/Fahrenheit.Tools.STEP.csproj
+++ b/src/step/Fahrenheit.Tools.STEP.csproj
@@ -18,8 +18,8 @@
 
     <!-- PUBLISH SETTINGS -->
     <PropertyGroup>
-        <PublishSingleFile>true</PublishSingleFile>
-        <SelfContained>false</SelfContained>
+        <!-- STEP should not be part of 'deploy', hence unpublishable -->
+        <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
     <!-- SHARED FILE LINKS -->


### PR DESCRIPTION
STEP is an internal development tool that is of no use to consumers of Fahrenheit packages. We should not be shipping it.

Additionally, restrict and clarify an overbroad `unsafe` in texture API.