### PR TITLE
Add DEdit macro decompiler mode, rename {PAUSE} dialogue op

### DIFF
--- a/scripts/dedit_decompile_macrodic_new_chpc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_chpc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+Chinese
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_chpc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_depc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_depc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+German
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_depc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_frpc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_frpc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+French
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_frpc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_itpc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_itpc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+Italian
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_itpc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_jppc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_jppc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+Japanese
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_jppc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_krpc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_krpc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+Korean
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_krpc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_sppc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_sppc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+Spanish
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_sppc\menu\macrodic.dcp"

--- a/scripts/dedit_decompile_macrodic_new_uspc.rsp
+++ b/scripts/dedit_decompile_macrodic_new_uspc.rsp
@@ -1,0 +1,9 @@
+decompile-macro
+-o
+.
+-l
+English
+-g
+FFX
+-i
+"..\env\ffx_ps2\ffx\master\new_uspc\menu\macrodic.dcp"

--- a/src/core/encoding.cs
+++ b/src/core/encoding.cs
@@ -69,7 +69,7 @@ public static class FhEncoding {
 
     private static ReadOnlySpan<byte> _newline    => "\r\n"u8;
     private static ReadOnlySpan<byte> _op_end     => "{END}"u8;     // 0x00
-    private static ReadOnlySpan<byte> _op_pause   => "{PAUSE}"u8;   // 0x01
+    private static ReadOnlySpan<byte> _op_break   => "{BREAK}"u8;   // 0x01
     private static ReadOnlySpan<byte> _op_newline => "{LF}"u8;      // 0x03
     private static ReadOnlySpan<byte> _op_space   => "{SPACE:"u8;   // 0x07
     private static ReadOnlySpan<byte> _op_time    => "{TIME:"u8;    // 0x09
@@ -80,6 +80,46 @@ public static class FhEncoding {
     private static ReadOnlySpan<byte> _op_macro   => "{MACRO:"u8;   // 0x13-0x22
     private static ReadOnlySpan<byte> _op_key     => "{KEY:"u8;     // 0x23
     private static ReadOnlySpan<byte> _op_unknown => "{UNKNOWN:"u8; // any other
+
+    /// <summary>
+    ///     Returns the UTF-8 plaintext literal corresponding to a given text <paramref name="op_code"/>.
+    /// </summary>
+    private static ReadOnlySpan<byte> _select_op_literal(byte op_code) {
+        return op_code switch {
+            0x00                => _op_end,
+            0x01                => _op_break,
+            0x03                => _op_newline,
+            0x07                => _op_space,
+            0x09                => _op_time,
+            0x0A                => _op_color,
+            0x0B                => _op_btn,
+            0x10                => _op_choice,
+            0x12                => _op_var,
+            >= 0x13 and <= 0x22 => _op_macro,
+            0x23                => _op_key,
+            _                   => _op_unknown,
+        };
+    }
+
+    /// <summary>
+    ///     Returns the op code corresponding to a UTF-8 text op <paramref name="expression"/>.
+    /// </summary>
+    private static byte _select_op_code(ReadOnlySpan<byte> expression) {
+        return 0 switch {
+            _ when expression.IndexOf(_op_end    ) != -1 => 0x00,
+            _ when expression.IndexOf(_op_break  ) != -1 => 0x01,
+            _ when expression.IndexOf(_op_newline) != -1 => 0x03,
+            _ when expression.IndexOf(_op_space  ) != -1 => 0x07,
+            _ when expression.IndexOf(_op_time   ) != -1 => 0x09,
+            _ when expression.IndexOf(_op_color  ) != -1 => 0x0A,
+            _ when expression.IndexOf(_op_btn    ) != -1 => 0x0B,
+            _ when expression.IndexOf(_op_choice ) != -1 => 0x10,
+            _ when expression.IndexOf(_op_var    ) != -1 => 0x12,
+            _ when expression.IndexOf(_op_macro  ) != -1 => byte.CreateChecked(0x13 + _get_op_arg1(expression, _op_macro)),
+            _ when expression.IndexOf(_op_key    ) != -1 => 0x23,
+            _                                            => _get_op_arg1(expression, _op_unknown),
+        };
+    }
 
     /// <summary>
     ///     Gets the first argument of a text <paramref name="op"/> from an UTF-8 plaintext <paramref name="expression"/>.
@@ -114,7 +154,7 @@ public static class FhEncoding {
         ReadOnlySpan<byte> op = _select_op_literal(op_code);
         op.CopyTo(dest);
 
-        return op.Length + Encoding.UTF8.GetBytes($"{op_arg1:X2}}}", dest[op.Length .. ]);
+        return op.Length + Encoding.UTF8.GetBytes($"{op_arg1:X2}}}", dest[ op.Length .. ]);
     }
 
     /// <summary>
@@ -125,7 +165,7 @@ public static class FhEncoding {
         ReadOnlySpan<byte> op = _select_op_literal(op_code);
         op.CopyTo(dest);
 
-        return op.Length + Encoding.UTF8.GetBytes($"{op_arg1:X2}:{op_arg2:X2}}}", dest[op.Length .. ]);
+        return op.Length + Encoding.UTF8.GetBytes($"{op_arg1:X2}:{op_arg2:X2}}}", dest[ op.Length .. ]);
     }
 
     /// <summary>
@@ -201,46 +241,6 @@ public static class FhEncoding {
         return language is FhLangId.Chinese
                         or FhLangId.Japanese
                         or FhLangId.Korean;
-    }
-
-    /// <summary>
-    ///     Returns the UTF-8 plaintext literal corresponding to a given text <paramref name="op_code"/>.
-    /// </summary>
-    private static ReadOnlySpan<byte> _select_op_literal(byte op_code) {
-        return op_code switch {
-            0x00                => _op_end,
-            0x01                => _op_pause,
-            0x03                => _op_newline,
-            0x07                => _op_space,
-            0x09                => _op_time,
-            0x0A                => _op_color,
-            0x0B                => _op_btn,
-            0x10                => _op_choice,
-            0x12                => _op_var,
-            >= 0x13 and <= 0x22 => _op_macro,
-            0x23                => _op_key,
-            _                   => _op_unknown,
-        };
-    }
-
-    /// <summary>
-    ///     Returns the op code corresponding to a UTF-8 text op <paramref name="expression"/>.
-    /// </summary>
-    private static byte _select_op_code(ReadOnlySpan<byte> expression) {
-        return expression switch {
-            _ when expression.IndexOf(_op_end    ) != -1 => 0x00,
-            _ when expression.IndexOf(_op_pause  ) != -1 => 0x01,
-            _ when expression.IndexOf(_op_newline) != -1 => 0x03,
-            _ when expression.IndexOf(_op_space  ) != -1 => 0x07,
-            _ when expression.IndexOf(_op_time   ) != -1 => 0x09,
-            _ when expression.IndexOf(_op_color  ) != -1 => 0x0A,
-            _ when expression.IndexOf(_op_btn    ) != -1 => 0x0B,
-            _ when expression.IndexOf(_op_choice ) != -1 => 0x10,
-            _ when expression.IndexOf(_op_var    ) != -1 => 0x12,
-            _ when expression.IndexOf(_op_macro  ) != -1 => byte.CreateChecked(0x13 + _get_op_arg1(expression, _op_macro)),
-            _ when expression.IndexOf(_op_key    ) != -1 => 0x23,
-            _                                            => _get_op_arg1(expression, _op_unknown),
-        };
     }
 
     /// <summary>

--- a/src/dedit/main.cs
+++ b/src/dedit/main.cs
@@ -85,7 +85,7 @@ internal static class Program {
             AllowMultipleArgumentsPerToken = true
         };
 
-        Option<string> opt_output = new("--output", "-o") {
+        Option<string> opt_output_dir = new("--output", "-o") {
             Description = "What folder to emit outputs to. The folder must already exist.",
             Arity       = ArgumentArity.ExactlyOne,
             Recursive   = true
@@ -130,7 +130,7 @@ internal static class Program {
         };
 
         cmd_root.Options.Add(opt_input);
-        cmd_root.Options.Add(opt_output);
+        cmd_root.Options.Add(opt_output_dir);
         cmd_root.Options.Add(opt_segment);
         cmd_root.Options.Add(opt_encoding);
         cmd_root.Options.Add(opt_lang);
@@ -138,11 +138,13 @@ internal static class Program {
         cmd_root.Options.Add(opt_game);
         cmd_root.Options.Add(opt_macrodict);
 
-        Command cmd_decompile = new("decompile", "Decompiles a dialogue file.");
+        Command cmd_decompile       = new("decompile",       "Decompiles a dialogue file.");
+        Command cmd_decompile_macro = new("decompile-macro", "Decompiles a macro dictionary file.");
+        Command cmd_compile         = new("compile",         "Compiles a dialogue file.");
 
         cmd_decompile.SetAction(parse_result => _c_decompile(
             parse_result.GetRequiredValue(opt_input),
-            parse_result.GetRequiredValue(opt_output),
+            parse_result.GetRequiredValue(opt_output_dir),
             parse_result.GetValue        (opt_segment),
             parse_result.GetRequiredValue(opt_encoding),
             parse_result.GetRequiredValue(opt_lang),
@@ -150,13 +152,16 @@ internal static class Program {
             parse_result.GetRequiredValue(opt_game)
             ));
 
-        Command cmd_decompile_macro = new("decompile-macro", "Decompiles a macro dictionary file.");
-
-        Command cmd_compile = new("compile", "Compiles a dialogue file.");
+        cmd_decompile_macro.SetAction(parse_result => _c_decompile_macro(
+            parse_result.GetRequiredValue(opt_input),
+            parse_result.GetRequiredValue(opt_output_dir),
+            parse_result.GetRequiredValue(opt_lang),
+            parse_result.GetRequiredValue(opt_game)
+        ));
 
         cmd_compile.SetAction(parse_result => _c_compile(
             parse_result.GetRequiredValue(opt_input),
-            parse_result.GetRequiredValue(opt_output),
+            parse_result.GetRequiredValue(opt_output_dir),
             parse_result.GetRequiredValue(opt_encoding),
             parse_result.GetRequiredValue(opt_lang),
             parse_result.GetRequiredValue(opt_index),
@@ -165,6 +170,7 @@ internal static class Program {
             ));
 
         cmd_root.Subcommands.Add(cmd_decompile);
+        cmd_root.Subcommands.Add(cmd_decompile_macro);
         cmd_root.Subcommands.Add(cmd_compile);
 
         ParseResult argparse_result = cmd_root.Parse(args);
@@ -172,12 +178,12 @@ internal static class Program {
     }
 
     /// <summary>
-    ///     Converts all game-encoded dialogue files in <paramref name="input"/> into text files in DEdit syntax, for a specified
-    ///     <paramref name="game"/>, <paramref name="index_type"/>, and <paramref name="lang"/>, emitting them to <paramref name="output"/>.
+    ///     Converts all game-encoded dialogue files in <paramref name="input_files"/> into text files in DEdit syntax, for a specified
+    ///     <paramref name="game"/>, <paramref name="index_type"/>, and <paramref name="lang"/>, emitting them to <paramref name="output_dir"/>.
     /// </summary>
     private static void _c_decompile(
-        List<FileInfo>  input,
-        string          output,
+        List<FileInfo>  input_files,
+        string          output_dir,
         Range           segment,
         FhDEditEncoding encoding,
         FhLangId        lang,
@@ -186,8 +192,8 @@ internal static class Program {
     {
         Stopwatch perf = Stopwatch.StartNew();
 
-        foreach (FileInfo input_file in input) {
-            string output_path = Path.Join(output, $"{input_file.Name}.txt");
+        foreach (FileInfo input_file in input_files) {
+            string output_path = Path.Join(output_dir, $"{input_file.Name}.txt");
 
             using (FileStream input_file_stream  = input_file.OpenRead())
             using (FileStream output_file_stream = new FileStream(output_path, FileMode.Create, FileAccess.Write, FileShare.None)) {
@@ -197,7 +203,33 @@ internal static class Program {
             Console.WriteLine($"{input_file.Name} -> {output_path}");
         }
 
-        Console.WriteLine($"processed {input.Count} files in {perf.Elapsed}");
+        Console.WriteLine($"processed {input_files.Count} files in {perf.Elapsed}");
+    }
+
+    /// <summary>
+    ///     Converts all game-encoded macro dictionaries in <paramref name="input_files"/> into text files in DEdit syntax, for a specified
+    ///     <paramref name="game"/> and <paramref name="lang"/>, emitting them to <paramref name="output_dir"/>.
+    /// </summary>
+    private static void _c_decompile_macro(
+        List<FileInfo> input_files,
+        string         output_dir,
+        FhLangId       lang,
+        FhGameId       game)
+    {
+        Stopwatch perf = Stopwatch.StartNew();
+
+        foreach (FileInfo input_file in input_files) {
+            string output_path = Path.Join(output_dir, $"{input_file.Name}.txt");
+
+            using (FileStream input_file_stream  = input_file.OpenRead())
+            using (FileStream output_file_stream = new FileStream(output_path, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                _decompile_macro(input_file_stream, lang, game, output_file_stream);
+            }
+
+            Console.WriteLine($"{input_file.Name} -> {output_path}");
+        }
+
+        Console.WriteLine($"processed {input_files.Count} files in {perf.Elapsed}");
     }
 
     /// <summary>
@@ -245,13 +277,15 @@ internal static class Program {
 
     /// <summary>
     ///     Processes a input <paramref name="macro_dict_file"/>, enabling its use to resolve {MACRO} ops during (de)compilation.
+    ///     If an <paramref name="output_file"/> is given, then the decoded contents are also emitted to that file.
     ///     <para/>
     ///     The correct <paramref name="lang"/> and <paramref name="game"/> must be specified.
     /// </summary>
-    private static void _macrodict_load(
-        FileStream macro_dict_file,
-        FhLangId   lang,
-        FhGameId   game)
+    private static void _decompile_macro(
+        FileStream  macro_dict_file,
+        FhLangId    lang,
+        FhGameId    game,
+        FileStream? output_file = null)
     {
         Span<byte> macro_dict_bytes = new byte[macro_dict_file.Length];
         macro_dict_file.ReadExactly(macro_dict_bytes);
@@ -294,6 +328,7 @@ internal static class Program {
                 byte[]             dest = ArrayPool<byte>.Shared.Rent(FhEncoding.compute_decode_buffer_size(src, lang, game));
 
                 int dest_written  = FhEncoding.decode(src, dest, lang, game);
+                output_file?.Write(dest.AsSpan()[ .. dest_written ]);
                 _macro_refs[i][k] = Encoding.UTF8.GetString(dest[ .. dest_written ]);
 
                 ArrayPool<byte>.Shared.Return(dest);
@@ -379,7 +414,7 @@ internal static class Program {
         FhTextIndexType index_type,
         FhGameId        game)
     {
-        _macrodict_load(macro_dict_file, lang, game);
+        _decompile_macro(macro_dict_file, lang, game);
 
         Span<byte> input_bytes = new byte[input_file.Length];
         input_file.ReadExactly(input_bytes);


### PR DESCRIPTION
In `src/core/encoding.cs`, the diff seems larger because I've moved the op switch tables right next to the op definitions for ease of amending (since any new or changed op-def needs updating in all three).