### PR TITLE
Support `win-x86`, `win-x64`, and `linux-x64` RIDs seamlessly

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -26,11 +26,7 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        architecture: [ x86 ]
-        os: [ windows ]
-    runs-on: ${{ matrix.os }}-2025
+    runs-on: windows-2025
 
     steps:
     - name: Print runner environment

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -52,7 +52,6 @@
         </ItemGroup>
     </Target>
 
-
     <!-- fkelava 09/06/26 17:36
     A placeholder target to force publishing to occur after a build.
     Publishing places build output in its proper place.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,38 +22,36 @@
             <ProjectReference Include="@(_TransitiveProjectReferences)" Private="False" />
         </ItemGroup>
     </Target>
-
-    <!-- fkelava 01/10/25 11:17
-    https://github.com/dotnet/sdk/issues/25411
-    https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#post-processing-binaries-before-bundling
-
-    We have a number of large runtime and native deps. They must be shared.
-
-    Mods handle this by using <ExcludeAssets>runtime;native</ExcludeAssets>
-    when referencing Fahrenheit core or mod libraries.
-    The loader ensures that each core or mod library is loaded only once.
-
-    .NET probes only trusted framework paths when DLL loading. All other dependencies
-    are given in a `.deps.json` file with a path hint. <ExcludeAssets> purges
-    the associated dependency's hint, implicitly demanding that it be loaded before it is required.
-
-    This is always true for the usual use case, the plugin framework. For standalone tools
-    this is never true and causes load errors. An alternative, <ExcludeFromSingleFile> is
-    available, but suffers from two crippling flaws:
-    - it has no effect on <PackageReference>s
-    - it does not exclude transitive runtime and native dependencies of a <ProjectReference>
-
-    Until it does, we specify it to get a valid `.deps.json`, then purge shared dep DLLs in this target to simulate its effect.
+    
+    <!-- fkelava 21/07/26 00:25
+    https://github.com/dotnet/sdk/issues/42153
+    
+    We no longer build everything for `win-x86`, but instead support three RIDs: `win-x86`, `win-x64`, `linux-x64`.
+    Each project specifies its supported RIDs with <RuntimeIdentifiers>. But the SDK doesn't use that to filter
+    the native DLLs it will output; it's just a hint for NuGet package restore purposes.
+    
+    This target serves to accomplish that purpose so we don't ship DLLs for platforms we don't support.
     -->
-    <Target Name="__FhExplicitRemoveFromFilesToBundle" BeforeTargets="GenerateSingleFileBundle" DependsOnTargets="PrepareForBundle">
-        <Message Text="List of bundle objects before purging: '@(FilesToBundle)'" Importance="High" />
-
-        <!--
-        TODO: TEMPORARILY STUBBED OUT PENDING BUILD SYSTEM CHANGES IN #215
-        -->
-
-        <Message Text="List of bundle objects after purging: '@(FilesToBundle)'" Importance="High" />
+    <Target Name="FilterRuntimeTargetItems" AfterTargets="ResolvePackageAssets" BeforeTargets="ResolveLockFileReferences">
+        <ItemGroup>
+            <_AssetFilteringRids Include="win-x86;win-x64;linux-x64" />
+        </ItemGroup>
+        
+        <!-- Invoke SelectRuntimeIdentifierSpecificItems for each filtering RID to get just the items that are compatible with that RID -->
+        <SelectRuntimeIdentifierSpecificItems 
+            Items="@(RuntimeTargetsCopyLocalItems)"
+            TargetRuntimeIdentifier="%(_AssetFilteringRids.Identity)"
+            RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)" >
+            
+            <Output TaskParameter="SelectedItems" ItemName="_FilteredRuntimeTargetsCopyLocalItems" />
+        </SelectRuntimeIdentifierSpecificItems>
+        
+        <ItemGroup>
+            <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)" />
+            <RuntimeTargetsCopyLocalItems Include="@(_FilteredRuntimeTargetsCopyLocalItems)" />
+        </ItemGroup>
     </Target>
+
 
     <!-- fkelava 09/06/26 17:36
     A placeholder target to force publishing to occur after a build.

--- a/src/atelier/Fahrenheit.Tools.Atelier.csproj
+++ b/src/atelier/Fahrenheit.Tools.Atelier.csproj
@@ -6,7 +6,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
@@ -19,8 +19,8 @@
 
     <!-- PUBLISH SETTINGS -->
     <PropertyGroup>
-        <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <!-- SHARED FILE LINKS -->
@@ -30,9 +30,7 @@
 
     <!-- PROJECT REFERENCES -->
     <ItemGroup>
-        <ProjectReference Include="..\core\Fahrenheit.csproj">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        </ProjectReference>
+        <ProjectReference Include="..\core\Fahrenheit.csproj" />
     </ItemGroup>
 
     <!-- PACKAGE REFERENCES -->

--- a/src/core/Fahrenheit.csproj
+++ b/src/core/Fahrenheit.csproj
@@ -36,7 +36,7 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifiers>win-x86;win-x64;linux-x64</RuntimeIdentifiers>
         <EnableDynamicLoading>true</EnableDynamicLoading>
     </PropertyGroup>
 
@@ -60,7 +60,7 @@
 
     <!-- EXTERNAL PROJECT REFS -->
     <ItemGroup>
-        <PackageReference Include="Blake3" Version="2.2.1" />
+        <PackageReference Include="Blake3" Version="3.0.2" />
         <PackageReference Include="Hexa.NET.DirectXTex" Version="2.0.4" />
         <PackageReference Include="Hexa.NET.ImGui.Backends" Version="1.0.18" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">

--- a/src/core/bootloader.cs
+++ b/src/core/bootloader.cs
@@ -137,8 +137,6 @@ internal sealed class FhLoader {
         Assembly self = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Join(FhEnvironment.Finder.Binaries.FullName, "fh.dll"));
         FhInternal.Log.Info($"Fahrenheit {FileVersionInfo.GetVersionInfo(self.Location).ProductVersion}");
 
-        // required for Hexa.NET.ImGui's assembly-probing logic
-        HexaGen.Runtime.LibraryLoader.CustomLoadFolders.Add(FhEnvironment.Finder.Binaries.FullName);
     }
 
     /// <summary>

--- a/src/dedit/Fahrenheit.Tools.DEdit.csproj
+++ b/src/dedit/Fahrenheit.Tools.DEdit.csproj
@@ -6,8 +6,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     </PropertyGroup>
 
     <!-- ASSEMBLY ADDITIONAL PROPERTIES -->
@@ -19,8 +19,8 @@
 
     <!-- PUBLISH SETTINGS -->
     <PropertyGroup>
-        <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <!-- SHARED FILE LINKS -->
@@ -30,9 +30,7 @@
 
     <!-- PROJECT REFERENCES -->
     <ItemGroup>
-        <ProjectReference Include="..\core\Fahrenheit.csproj">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        </ProjectReference>
+        <ProjectReference Include="..\core\Fahrenheit.csproj" />
     </ItemGroup>
 
     <!-- PACKAGE REFERENCES -->

--- a/src/eedit/Fahrenheit.Tools.EEdit.csproj
+++ b/src/eedit/Fahrenheit.Tools.EEdit.csproj
@@ -6,8 +6,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     </PropertyGroup>
 
     <!-- ASSEMBLY ADDITIONAL PROPERTIES -->
@@ -19,8 +19,8 @@
 
     <!-- PUBLISH SETTINGS -->
     <PropertyGroup>
-        <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <!-- SHARED FILE LINKS -->
@@ -30,9 +30,7 @@
 
     <!-- PROJECT REFERENCES -->
     <ItemGroup>
-        <ProjectReference Include="..\core\Fahrenheit.csproj">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        </ProjectReference>
+        <ProjectReference Include="..\core\Fahrenheit.csproj" />
     </ItemGroup>
 
     <!-- PACKAGE REFERENCES -->

--- a/src/modmgr/Fahrenheit.Tools.ModManager.csproj
+++ b/src/modmgr/Fahrenheit.Tools.ModManager.csproj
@@ -6,8 +6,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <!-- ASSEMBLY ADDITIONAL PROPERTIES -->
@@ -19,8 +19,8 @@
 
     <!-- PUBLISH SETTINGS -->
     <PropertyGroup>
-        <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <!-- APPLICATION ASSETS -->

--- a/src/runtime/Fahrenheit.Runtime.csproj
+++ b/src/runtime/Fahrenheit.Runtime.csproj
@@ -15,7 +15,7 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifiers>win-x86</RuntimeIdentifiers>
         <EnableDynamicLoading>true</EnableDynamicLoading>
     </PropertyGroup>
 

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -39,6 +39,7 @@ EXCEPTION_POINTERS* g_eh_exception_ptr;
 
 // Globals to hold hostfxr exports
 hostfxr_initialize_for_runtime_config_fn g_fnptr_hostfxr_init;
+hostfxr_set_runtime_property_value_fn    g_fnptr_hostfxr_set_runtime_property;
 hostfxr_get_runtime_delegate_fn          g_fnptr_hostfxr_get_delegate;
 hostfxr_close_fn                         g_fnptr_hostfxr_close;
 
@@ -60,11 +61,15 @@ static bool load_hostfxr() {
     if (lib == nullptr)
         return FALSE;
 
-    g_fnptr_hostfxr_init         = (hostfxr_initialize_for_runtime_config_fn)::GetProcAddress(lib, "hostfxr_initialize_for_runtime_config");
-    g_fnptr_hostfxr_get_delegate = (hostfxr_get_runtime_delegate_fn)         ::GetProcAddress(lib, "hostfxr_get_runtime_delegate");
-    g_fnptr_hostfxr_close        = (hostfxr_close_fn)                        ::GetProcAddress(lib, "hostfxr_close");
+    g_fnptr_hostfxr_init                 = (hostfxr_initialize_for_runtime_config_fn)::GetProcAddress(lib, "hostfxr_initialize_for_runtime_config");
+    g_fnptr_hostfxr_set_runtime_property = (hostfxr_set_runtime_property_value_fn)   ::GetProcAddress(lib, "hostfxr_set_runtime_property_value");
+    g_fnptr_hostfxr_get_delegate         = (hostfxr_get_runtime_delegate_fn)         ::GetProcAddress(lib, "hostfxr_get_runtime_delegate");
+    g_fnptr_hostfxr_close                = (hostfxr_close_fn)                        ::GetProcAddress(lib, "hostfxr_close");
 
-    return (g_fnptr_hostfxr_init && g_fnptr_hostfxr_get_delegate && g_fnptr_hostfxr_close);
+    return g_fnptr_hostfxr_init
+        && g_fnptr_hostfxr_set_runtime_property
+        && g_fnptr_hostfxr_get_delegate
+        && g_fnptr_hostfxr_close;
 }
 
 /* [fkelava 11/06/26 16:27]
@@ -381,6 +386,19 @@ static int stage1_main(void) {
     }
 
     // STEP 7:
+    // Set up AppContext.BaseDirectory so we can use it to find runtime dependencies.
+    rc = g_fnptr_hostfxr_set_runtime_property(
+        cxt,
+        L"APP_CONTEXT_BASE_DIRECTORY",
+        cwd_path.c_str());
+
+    if (rc != 0) {
+        std::wcerr << "hostfxr: failed to set APP_CONTEXT_BASE_DIRECTORY" << std::endl;
+        std::wcerr << "This is an uncommon error. Please contact the Fahrenheit developers at https://github.com/fahrenheit-crew/fahrenheit." << std::endl;
+        exit(rc);
+    }
+
+    // STEP 8:
     // Get function pointers to HostFxr's `load_assembly()` and `get_function_pointer()`.
     rc = g_fnptr_hostfxr_get_delegate(
         cxt,
@@ -409,7 +427,7 @@ static int stage1_main(void) {
     load_assembly_fn        fnptr_hostfxr_load_assembly        = (load_assembly_fn)       ptr_hostfxr_load_assembly;
     get_function_pointer_fn fnptr_hostfxr_get_function_pointer = (get_function_pointer_fn)ptr_hostfxr_get_function_pointer;
 
-    // STEP 8:
+    // STEP 9:
     // Load managed assembly and get function pointer to bootstrap function.
     fh_init fnptr_fh_init = nullptr;
 
@@ -438,14 +456,14 @@ static int stage1_main(void) {
         exit(rc);
     }
 
-    // STEP 9:
+    // STEP 10:
     // Boot Fahrenheit by invoking the boot function in `fh.dll`.
 
     // TRANSITION: NATIVE -> MANAGED
     fnptr_fh_init();
     // TRANSITION: MANAGED -> NATIVE
 
-    // STEP 10:
+    // STEP 11:
     // Change the working directory to the targeted executable's location,
     // now that we have finished initialization.
     rc = _wchdir(host_path.c_str());

--- a/src/step/Fahrenheit.Tools.STEP.csproj
+++ b/src/step/Fahrenheit.Tools.STEP.csproj
@@ -6,7 +6,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <!-- ASSEMBLY ADDITIONAL PROPERTIES -->
@@ -29,9 +29,7 @@
 
     <!-- PROJECT REFERENCES -->
     <ItemGroup>
-        <ProjectReference Include="..\core\Fahrenheit.csproj">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        </ProjectReference>
+        <ProjectReference Include="..\core\Fahrenheit.csproj" />
     </ItemGroup>
 
     <!-- PACKAGE REFERENCES -->

--- a/test/Fahrenheit.Tests.csproj
+++ b/test/Fahrenheit.Tests.csproj
@@ -6,7 +6,10 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    </PropertyGroup>
+
+    <!-- PACKAGING CONFIGURATION -->
+    <PropertyGroup>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
@@ -35,14 +38,14 @@
     <!-- EXTERNAL PROJECT REFS -->
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.4">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.11.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     </ItemGroup>


### PR DESCRIPTION
Closes #215.

Fahrenheit and its tools should now no longer be locked to `win-x86` mode, allowing native tool builds on Linux and 64-bit tool builds on Windows.