### PR TITLE
Raise `vcpkg` baseline, extend boot prints

### DIFF
--- a/src/core/bootloader.cs
+++ b/src/core/bootloader.cs
@@ -135,7 +135,10 @@ internal sealed class FhLoader {
     internal FhLoader() {
         // Loading the core library into ALC.Default ensures it does not 'leak' into plugins' load contexts, causing type identity mismatches.
         Assembly self = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Join(FhEnvironment.Finder.Binaries.FullName, "fh.dll"));
-        FhInternal.Log.Info($"Fahrenheit {FileVersionInfo.GetVersionInfo(self.Location).ProductVersion}");
+        FhInternal.Log.LogDirect($"----");
+        FhInternal.Log.LogDirect($"Fahrenheit {FileVersionInfo.GetVersionInfo(self.Location).ProductVersion}");
+        FhInternal.Log.LogDirect($"OS: {RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}, target: {RuntimeInformation.RuntimeIdentifier}");
+        FhInternal.Log.LogDirect($"----");
 
         // required for Hexa.NET.ImGui's assembly-probing logic
         HexaGen.Runtime.LibraryLoader.CustomLoadFolders.Add(FhEnvironment.Finder.Binaries.FullName);

--- a/src/stage0/vcpkg-configuration.json
+++ b/src/stage0/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "7f9f0e44db287e8e67c0e888141bfa200ab45121",
+    "baseline": "4bca8fd8654e5ba76f92661db7bfe954768ad8ef",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/src/stage1/vcpkg-configuration.json
+++ b/src/stage1/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "7f9f0e44db287e8e67c0e888141bfa200ab45121",
+    "baseline": "4bca8fd8654e5ba76f92661db7bfe954768ad8ef",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
We haven't updated our `vcpkg` baseline since we first switched to it. This unlocks the use of newer `detours`, `nethost` and `minhook` binaries.