### PR TITLE
Provide a RAII type to manipulate memory protection

### DIFF
--- a/src/core/native/NativeMethods.txt
+++ b/src/core/native/NativeMethods.txt
@@ -20,6 +20,10 @@ LRESULT
 HRESULT
 HMODULE
 
+// Memory protection modifier
+
+VirtualProtect
+
 // RT: Allocator fix
 
 InitializeCriticalSection

--- a/src/core/protmem.cs
+++ b/src/core/protmem.cs
@@ -19,13 +19,13 @@ public unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
     private readonly PAGE_PROTECTION_FLAGS _protection_flags_old;
 
     /// <summary>
-    ///     Changes the memory protection mode beginning at the given <paramref name="address"/> to <paramref name="protection_mode"/>.
+    ///     Changes the memory protection mode beginning at the given address.
     /// </summary>
     /// <remarks>
     ///     The protection of any memory page containing one or more bytes from <paramref name="address"/> to
     ///     (<paramref name="address"/> + sizeof(<typeparamref name="T"/>)) will be changed.
     /// </remarks>
-    /// <param name="address">The starting address to change the memory protection mode at.</param>
+    /// <param name="address">The address to start change the memory protection mode from.</param>
     /// <param name="protection_mode">The memory protection mode to set for the targeted memory region.</param>
     public FhVirtualProtectScope(T* address, PAGE_PROTECTION_FLAGS protection_mode) {
         PAGE_PROTECTION_FLAGS flOldProtect;

--- a/src/core/protmem.cs
+++ b/src/core/protmem.cs
@@ -19,18 +19,24 @@ public unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
     private readonly PAGE_PROTECTION_FLAGS _protection_flags_old;
 
     /// <summary>
-    ///     Changes the page protection at the given <paramref name="address"/> to <paramref name="protection_flags"/>.
+    ///     Changes the memory protection mode beginning at the given <paramref name="address"/> to <paramref name="protection_mode"/>.
     /// </summary>
-    public FhVirtualProtectScope(T* address, PAGE_PROTECTION_FLAGS protection_flags) {
+    /// <remarks>
+    ///     The protection of any memory page containing one or more bytes from <paramref name="address"/> to
+    ///     (<paramref name="address"/> + sizeof(<typeparamref name="T"/>)) will be changed.
+    /// </remarks>
+    /// <param name="address">The starting address to change the memory protection mode at.</param>
+    /// <param name="protection_mode">The memory protection mode to set for the targeted memory region.</param>
+    public FhVirtualProtectScope(T* address, PAGE_PROTECTION_FLAGS protection_mode) {
         PAGE_PROTECTION_FLAGS flOldProtect;
-        PInvoke.VirtualProtect(address, (nuint) sizeof(T), protection_flags, &flOldProtect);
+        PInvoke.VirtualProtect(address, (nuint) sizeof(T), protection_mode, &flOldProtect);
 
         _address              = address;
         _protection_flags_old = flOldProtect;
     }
 
     /// <summary>
-    ///     Reverts the page protection at the target address to its previous state.
+    ///     Reverts the memory protection mode of the targeted region to its previous state.
     /// </summary>
     public void Dispose() {
         PAGE_PROTECTION_FLAGS discard;

--- a/src/core/protmem.cs
+++ b/src/core/protmem.cs
@@ -1,0 +1,34 @@
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+// This file is part of Fahrenheit, © 2023-2026 The Fahrenheit contributors.
+// It is licensed to you under the GNU Lesser General Public License, version 3.0 or later. See COPYING, COPYING.LESSER.
+
+namespace Fahrenheit;
+
+/// <summary>
+///     A disposable structure which changes the protection flags on a memory location
+///     while it remains in scope, reverting to the original flags when disposed.
+/// </summary>
+/// <remarks>
+///     This is useful for rewriting constants embedded into read-only process sections,
+///     which would normally cause an access violation.
+/// </remarks>
+[SupportedOSPlatform("windows5.1.2600")]
+internal unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
+    private readonly T*                    _lpAddress;
+    private readonly PAGE_PROTECTION_FLAGS _flOldProtect;
+
+    public FhVirtualProtectScope(T* lpAddress, PAGE_PROTECTION_FLAGS flNewProtect) {
+        PAGE_PROTECTION_FLAGS flOldProtect;
+        PInvoke.VirtualProtect(lpAddress, (nuint) sizeof(T), flNewProtect, &flOldProtect);
+
+        _lpAddress    = lpAddress;
+        _flOldProtect = flOldProtect;
+    }
+
+    public void Dispose() {
+        PAGE_PROTECTION_FLAGS discard;
+        PInvoke.VirtualProtect(_lpAddress, (nuint) sizeof(T), _flOldProtect, &discard);
+    }
+}
+

--- a/src/core/protmem.cs
+++ b/src/core/protmem.cs
@@ -25,7 +25,7 @@ public unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
     ///     The protection of any memory page containing one or more bytes from <paramref name="address"/> to
     ///     (<paramref name="address"/> + sizeof(<typeparamref name="T"/>)) will be changed.
     /// </remarks>
-    /// <param name="address">The address to start change the memory protection mode from.</param>
+    /// <param name="address">The address to start changing the memory protection mode from.</param>
     /// <param name="protection_mode">The memory protection mode to set for the targeted memory region.</param>
     public FhVirtualProtectScope(T* address, PAGE_PROTECTION_FLAGS protection_mode) {
         PAGE_PROTECTION_FLAGS flOldProtect;

--- a/src/core/protmem.cs
+++ b/src/core/protmem.cs
@@ -14,21 +14,27 @@ namespace Fahrenheit;
 ///     which would normally cause an access violation.
 /// </remarks>
 [SupportedOSPlatform("windows5.1.2600")]
-internal unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
-    private readonly T*                    _lpAddress;
-    private readonly PAGE_PROTECTION_FLAGS _flOldProtect;
+public unsafe readonly ref struct FhVirtualProtectScope<T> where T : unmanaged {
+    private readonly T*                    _address;
+    private readonly PAGE_PROTECTION_FLAGS _protection_flags_old;
 
-    public FhVirtualProtectScope(T* lpAddress, PAGE_PROTECTION_FLAGS flNewProtect) {
+    /// <summary>
+    ///     Changes the page protection at the given <paramref name="address"/> to <paramref name="protection_flags"/>.
+    /// </summary>
+    public FhVirtualProtectScope(T* address, PAGE_PROTECTION_FLAGS protection_flags) {
         PAGE_PROTECTION_FLAGS flOldProtect;
-        PInvoke.VirtualProtect(lpAddress, (nuint) sizeof(T), flNewProtect, &flOldProtect);
+        PInvoke.VirtualProtect(address, (nuint) sizeof(T), protection_flags, &flOldProtect);
 
-        _lpAddress    = lpAddress;
-        _flOldProtect = flOldProtect;
+        _address              = address;
+        _protection_flags_old = flOldProtect;
     }
 
+    /// <summary>
+    ///     Reverts the page protection at the target address to its previous state.
+    /// </summary>
     public void Dispose() {
         PAGE_PROTECTION_FLAGS discard;
-        PInvoke.VirtualProtect(_lpAddress, (nuint) sizeof(T), _flOldProtect, &discard);
+        PInvoke.VirtualProtect(_address, (nuint) sizeof(T), _protection_flags_old, &discard);
     }
 }
 

--- a/src/core/usings.cs
+++ b/src/core/usings.cs
@@ -35,4 +35,5 @@ global using Windows.Win32.Graphics.Dxgi.Common;
 global using Windows.Win32.Graphics.Gdi;
 global using Windows.Win32.UI.WindowsAndMessaging;
 global using Windows.Win32.System.Diagnostics.Debug;
+global using Windows.Win32.System.Memory;
 global using Windows.Win32.System.Threading;

--- a/src/core/util.cs
+++ b/src/core/util.cs
@@ -21,9 +21,18 @@ public unsafe static class FhUtil {
         };
     }
 
-    public static T* ptr_at<T>(nint address)          where T : unmanaged { return (T*)(FhEnvironment.BaseAddr + address); }
-    public static T  get_at<T>(nint address)          where T : unmanaged { return *ptr_at<T>(address);                    }
-    public static T  set_at<T>(nint address, T value) where T : unmanaged { return *ptr_at<T>(address) = value;            }
+    public static T* ptr_at<T>(nint address) where T : unmanaged => (T*)(FhEnvironment.BaseAddr + address);
+    public static T  get_at<T>(nint address) where T : unmanaged => *ptr_at<T>(address);
+
+    /// <summary>
+    ///     Writes a given <paramref name="value"/> of type <typeparamref name="T"/> to the given <paramref name="address"/>.
+    /// </summary>
+    /// <remarks>
+    ///     The target <paramref name="address"/> must be in a writable memory region.
+    ///     If it is not, you must use a <see cref="FhVirtualProtectScope{T}"/>.
+    /// </remarks>
+    /// <returns>The previous value at the given address.</returns>
+    public static T set_at<T>(nint address, T value) where T : unmanaged => *ptr_at<T>(address) = value;
 
     public static void cast_to_bytes<T>(in ReadOnlySpan<T> src, in Span<byte> dest, out int bytesWritten) where T : struct {
         bytesWritten = Unsafe.SizeOf<T>() * src.Length;

--- a/src/core/util.cs
+++ b/src/core/util.cs
@@ -23,7 +23,7 @@ public unsafe static class FhUtil {
 
     /// <summary>
     ///     Returns a pointer to <typeparamref name="T"/> at the absolute address obtained by
-    ///     adding the given <paramref name="offset"/> to the base address of the running game's executable.
+    ///     adding the given offset to the base address of the running game's executable.
     /// </summary>
     /// <param name="offset">The offset, from the running game executable's base address, to return a pointer to <typeparamref name="T"/> at.</param>
     /// <returns>A pointer to a value of type <typeparamref name="T"/> at the given address.</returns>
@@ -31,24 +31,30 @@ public unsafe static class FhUtil {
 
     /// <summary>
     ///     Reads a value of type <typeparamref name="T"/> from the address obtained by adding
-    ///     the given <paramref name="offset"/> to the base address of the running game's executable.
+    ///     the given offset to the base address of the running game's executable.
     /// </summary>
     /// <param name="offset">The offset, from the running game executable's base address, to read a value of type <typeparamref name="T"/> from.</param>
     /// <returns>The current value at the given address.</returns>
     public static T get_at<T>(nint offset) where T : unmanaged => *ptr_at<T>(offset);
 
     /// <summary>
-    ///     Writes a given <paramref name="value"/> of type <typeparamref name="T"/> to the address obtained
-    ///     by adding the given <paramref name="offset"/> to the base address of the running game's executable.
+    ///     Writes a given value of type <typeparamref name="T"/> to the address obtained
+    ///     by adding the given offset to the base address of the running game's executable.
     /// </summary>
     /// <remarks>
-    ///     The target <paramref name="offset"/> must be in a writable memory region.
-    ///     If it is not, you must use a <see cref="FhVirtualProtectScope{T}"/>.
+    ///     The target offset must be in a writable memory region. If it is not, you must
+    ///     use a <see cref="FhVirtualProtectScope{T}"/> to avoid an <see cref="AccessViolationException"/>.
     /// </remarks>
-    /// <param name="offset">The offset, from the running game executable's base address, to write the given <paramref name="value"/> to.</param>
+    /// <param name="offset">The offset, from the running game executable's base address, to write the given value to.</param>
     /// <param name="value">The value of type <typeparamref name="T"/> to write at the given address.</param>
     /// <returns>The previous value at the given address.</returns>
-    public static T set_at<T>(nint offset, T value) where T : unmanaged => *ptr_at<T>(offset) = value;
+    public static T set_at<T>(nint offset, T value) where T : unmanaged {
+        T* ptr = ptr_at<T>(offset);
+        T  old = *ptr;
+
+        *ptr = value;
+        return old;
+    }
 
     public static void cast_to_bytes<T>(in ReadOnlySpan<T> src, in Span<byte> dest, out int bytesWritten) where T : struct {
         bytesWritten = Unsafe.SizeOf<T>() * src.Length;

--- a/src/core/util.cs
+++ b/src/core/util.cs
@@ -21,8 +21,21 @@ public unsafe static class FhUtil {
         };
     }
 
-    public static T* ptr_at<T>(nint address) where T : unmanaged => (T*)(FhEnvironment.BaseAddr + address);
-    public static T  get_at<T>(nint address) where T : unmanaged => *ptr_at<T>(address);
+    /// <summary>
+    ///     Returns a pointer to <typeparamref name="T"/> at the absolute address obtained by
+    ///     adding the given <paramref name="offset"/> to the base address of the running game's executable.
+    /// </summary>
+    /// <param name="offset">The offset, from the running game executable's base address, to return a pointer to <typeparamref name="T"/> at.</param>
+    /// <returns>A pointer to a value of type <typeparamref name="T"/> at the given address.</returns>
+    public static T* ptr_at<T>(nint offset) where T : unmanaged => (T*)(FhEnvironment.BaseAddr + offset);
+
+    /// <summary>
+    ///     Reads a value of type <typeparamref name="T"/> from the address obtained by adding
+    ///     the given <paramref name="offset"/> to the base address of the running game's executable.
+    /// </summary>
+    /// <param name="offset">The offset, from the running game executable's base address, to read a value of type <typeparamref name="T"/> from.</param>
+    /// <returns>The current value at the given address.</returns>
+    public static T get_at<T>(nint offset) where T : unmanaged => *ptr_at<T>(offset);
 
     /// <summary>
     ///     Writes a given <paramref name="value"/> of type <typeparamref name="T"/> to the address obtained

--- a/src/core/util.cs
+++ b/src/core/util.cs
@@ -25,14 +25,17 @@ public unsafe static class FhUtil {
     public static T  get_at<T>(nint address) where T : unmanaged => *ptr_at<T>(address);
 
     /// <summary>
-    ///     Writes a given <paramref name="value"/> of type <typeparamref name="T"/> to the given <paramref name="address"/>.
+    ///     Writes a given <paramref name="value"/> of type <typeparamref name="T"/> to the address obtained
+    ///     by adding the given <paramref name="offset"/> to the base address of the running game's executable.
     /// </summary>
     /// <remarks>
-    ///     The target <paramref name="address"/> must be in a writable memory region.
+    ///     The target <paramref name="offset"/> must be in a writable memory region.
     ///     If it is not, you must use a <see cref="FhVirtualProtectScope{T}"/>.
     /// </remarks>
+    /// <param name="offset">The offset, from the running game executable's base address, to write the given <paramref name="value"/> to.</param>
+    /// <param name="value">The value of type <typeparamref name="T"/> to write at the given address.</param>
     /// <returns>The previous value at the given address.</returns>
-    public static T set_at<T>(nint address, T value) where T : unmanaged => *ptr_at<T>(address) = value;
+    public static T set_at<T>(nint offset, T value) where T : unmanaged => *ptr_at<T>(offset) = value;
 
     public static void cast_to_bytes<T>(in ReadOnlySpan<T> src, in Span<byte> dest, out int bytesWritten) where T : struct {
         bytesWritten = Unsafe.SizeOf<T>() * src.Length;


### PR DESCRIPTION
Constants in the game process can be writable or read-only. If read-only, the compiler will emit them into `.rdata` or a similar section which is _mapped_ read-only. Attempting to modify such a constant will take an access violation.

To permit this, we should provide a RAII type which temporarily changes the page protection on a given address while in scope, permitting such rewrites to be done safely.