### PR TITLE
Remove bogus incompatibility warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ To install/test your development build:
 and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).
 
 ## Compatibility notes
-Fahrenheit supplies its own External File Loader. If you separately use ffgriever's
-[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), the two may override each other.
+Fahrenheit is incompatible with ffgriever's
+[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader).
+Fahrenheit comes with an integrated external file loader. Existing file-based mods must be converted to Fahrenheit format.
 
 If you use [Untitled Project X](https://github.com/Kaldaien/UnX) with Fahrenheit,
 you **must** patch the game executable to be large-address-aware (apply the "4GB patch"). If you don't, you will run out of memory at boot.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Fahrenheit comes with an integrated external file loader. Existing file-based mo
 If you use [Untitled Project X](https://github.com/Kaldaien/UnX) with Fahrenheit,
 you **must** patch the game executable to be large-address-aware (apply the "4GB patch"). If you don't, you will run out of memory at boot.
 
+If you use [RivaTuner Statistics Server](https://www.guru3d.com/download/rtss-rivatuner-statistics-server-download/) with Fahrenheit,
+you **must** enable 'Use Microsoft Detours API hooking' in `Setup > General > Compatibility properties`.
+
 ## What's next?
 Time permitting, the goals (in no specific order) of the project are:
 - Provide actual code-behind, helper functions, and tooling to make various modding tasks approachable.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,11 @@ To install/test your development build:
 and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).
 
 ## Compatibility notes
-**Fahrenheit is incompatible** with [Untitled Project X](https://github.com/Kaldaien/UnX)
-and ffgriever's [External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader).
-Fahrenheit supplies its own External File Loader, and you can use [Roelin's Asset Converter](https://www.nexusmods.com/finalfantasy12/mods/288)
-for model and texture modding in conjunction with it.
+Fahrenheit supplies its own External File Loader. If you separately use ffgriever's
+[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), the two may override each other.
 
-Fahrenheit is also incompatible with [RivaTuner Statistics Server](https://www.guru3d.com/download/rtss-rivatuner-statistics-server-download/)
-when used in non-stealth mode.
+If you use [Untitled Project X](https://github.com/Kaldaien/UnX) with Fahrenheit,
+you **must** patch the game executable to be large-address-aware (apply the "4GB patch"). If you don't, you will run out of memory at boot.
 
 ## What's next?
 Time permitting, the goals (in no specific order) of the project are:


### PR DESCRIPTION
During early AP testing (as early as the initial region tests), users reported strange incompatibilities with software such as RivaTuner Statistics Server. In general, overlays and display manipulation software were found to not behave well.

We also found a purported 'issue' with UnX, and so in both cases, we added a compatibility warning suggesting Fahrenheit _does not work_ with them. At the time, I paid it no heed and trusted user reports.

Except, as it turns out, neither of these things were ever true. The crash with UnX occurs if the game binary is not 4G patched due to an out-of-memory condition triggering process teardown; the incompatibility with RTSS is conditioned on something entirely unrelated to stealth state after further testing. Both warnings should be removed, as Fahrenheit is in fact _not_ incompatible with them.